### PR TITLE
Stress Analyzer + Compatibility Fixes

### DIFF
--- a/src/README
+++ b/src/README
@@ -1,0 +1,12 @@
+Instructions on how to use ThrottleBot:
+
+1. Run stress_scheduler.py with python2.7 with the proper arguments.
+The mandatory arguments and options needed for Throttlebot to run correctly are the website_ip, victim_machine_public_ip, experiement_type, services to stress, resources to stress, and stressing policy. If there are multiple website_ips, victim_ips, services, and resources, separate them with a single comma ','. The optional arguments will vary depending on your experiment type and preference. For example, if I wanted to run an experiment to benchmark the performance of all todo-app services under all levels of stress to all resources, I could run:
+
+python2.7 stress_scheduler.py WEBSITE1,WEBSITE2,WEBSITE3 VICTIM1,VICTIM2,VICTIM3 todo-app --traffic_generator_public_ip=GENERATOR1 --stress_all_services --stress_all_resources --stress_search_policy='ALL'
+
+	where WEBSITE, VICTIM, and GENERATOR are the IPs for the websites, victim machines, and the traffic generator respectively.
+
+Refer to the help section for more information.
+
+2. If necessary, set the "password" variables for your SSH keys. Without this, Throttlebot cannot execute commands on the virtual machines. They are located within remote_execution.py and measure_performance_MEAN_py3.py.

--- a/src/causal_analysis.py
+++ b/src/causal_analysis.py
@@ -37,7 +37,7 @@ def calculate_total_delay_added(container_id, results, results_diff, increment, 
             network_time  += get_network_throttle_time(ssh_client, container_id, results_diff[increment][iteration_count]['network_inbound'], increment)
             print 'Network time added is {}'.format(network_time)
             total_delay_added += network_time
-    elif resource_field == 'Network':
+        elif resource_field == 'Network':
             total_delay_added += get_cpu_throttle_time(ssh_client, results_diff[increment][iteration_count]['cpu'], increment)
             print 'CPU ADDED IS {}'.format(total_delay_added)
             disk_delay= get_disk_throttle_time(ssh_client, results_diff[increment][iteration_count]['disk'], increment)

--- a/src/max_resource_capacity.py
+++ b/src/max_resource_capacity.py
@@ -6,7 +6,7 @@ from container_information import *
 def get_container_network_capacity(ssh_client, container_id):
     # Get the max capacity of the interface
     container_to_capacity = {}
-    cmd = 'cat /sys/class/net/{}/speed'.format(container_name)
+    cmd = 'cat /sys/class/net/{}/speed'.format(container_id)
     _, stdout, _ = ssh_client.exec_command(cmd)
 
     # This is tricky! It will vary by machine. Ignoring the prior command because its a theoretical guarantee and usage will depend on whether it is happening on the cloud or not

--- a/src/measure_performance_MEAN_py3.py
+++ b/src/measure_performance_MEAN_py3.py
@@ -52,7 +52,7 @@ def ssh_exec(ssh_client, cmd):
 def quilt_ssh(ip):
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.connect(ip, username="quilt")
+    client.connect(ip, username="quilt", password="")
     return client
 
 def make_single_POST(website_ip):
@@ -65,8 +65,8 @@ def make_single_POST(website_ip):
 
 def delete_posts(website_ip, all_ids):
     url = 'http://' + website_ip + REST_URL + '/'
-    for id in all_ids:
-        requests.delete(url + id)
+    for ids in all_ids:
+        requests.delete(url + ids)
 
 def GET_from_website(website_ip):
     url = 'http://' + website_ip + REST_URL

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -35,7 +35,7 @@ MAX_NETWORK_BANDWIDTH = 600
 
 #Fix Me!
 #Add a Network Delay to each of the container interfaces on VM
-def set_network_delay(ssh_client, delay):
+def set_network_delay(ssh_client, container_id, delay):
     if delay <= 0:
         invalid_resource_parameter('Network Delay', delay)
         return
@@ -73,7 +73,7 @@ def set_network_bandwidth(ssh_client, container_to_bandwidth, outgoing_traffic=T
 
 # Fix me!
 # Removes all network manipulations for ALL machines in the Quilt Environment
-def remove_all_network_manipulation(ssh_client, remove_all_machines=False):
+def remove_all_network_manipulation(ssh_client, container_id, remove_all_machines=False):
     all_machines = get_all_machines()
     if remove_all_machines is False:
         container_ids = get_container_id(ssh_client, full_id=False, append_c=True)

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -34,13 +34,13 @@ MAX_NETWORK_BANDWIDTH = 600
 '''Stressing the Network'''
 # Container_to_bandwidth maps Docker container id to the bandwidth that container should be throttled to.
 # Assumes that the container specified by container id is located in the machine for ssh_client
-# Bandwidth units: kbps
+# Bandwidth units: bps
 def set_egress_network_bandwidth(ssh_client, container_id, bandwidth):
     interface_name = get_container_veth(ssh_client, container_id)
 
     # Execute the command within OVS
-    # OVS policy bandwidth accepts inputs in kbps
-    bandwidth_kbps = bandwidth[container_id]
+    # OVS policy bandwidth accepts inputs in bps
+    bandwidth_kbps = bandwidth[container_id] / (10 ** 3)
     ovs_policy_cmd = 'ovs-vsctl set interface {} ingress_policing_rate={}'.format(interface_name, int(bandwidth_kbps))
     ovs_burst_cmd = 'ovs-vsctl set interface {} ingress_policing_burst={}'.format(interface_name, 0)
     docker_policing_cmd = "docker exec ovs-vswitchd {}".format(ovs_policy_cmd)
@@ -76,8 +76,8 @@ def reset_egress_network_bandwidth(ssh_client, container_id):
         print 'SUCCESS: Stress of container id {} removed'.format(container_id)
         return 1
 
-# Fix me!
-# Removes all network manipulations for ALL machines in the Quilt Environment
+# Unused
+# Removes all network manipulations for container_id (or ALL machines if specified) in the Quilt Environment
 def remove_all_network_manipulation(ssh_client, container_id, remove_all_machines=False):
     all_machines = get_all_machines()
     if remove_all_machines is False:

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -37,7 +37,7 @@ MAX_NETWORK_BANDWIDTH = 600
 # Bandwidth units: Mbps
 def set_egress_network_bandwidth(ssh_client, container_id, bandwidth):
     interface_name = get_container_veth(ssh_client, container_id)
-    
+
     # Execute the command within OVS
     # OVS policy bandwidth accepts inputs in kbps
     bandwidth_kbps = bandwidth * (10 ** 3)
@@ -117,7 +117,7 @@ def set_cpu_quota(ssh_client, container_id, cpu_period, cpu_quota):
 
 def reset_cpu_quota(ssh_client, container_id):
     # Reset only seems to work when both period and quota are high (and equal of course)
-    update_command = 'docker update --cpu-period=1000000 --cpu-quota=1000000 {}'.format(container_id)
+    update_command = 'docker update --cpu-quota=-1 {}'.format(container_id)
     print 'reset_cpu_quota'
     print update_command
     ssh_exec(ssh_client, update_command)

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -100,13 +100,16 @@ def plot_flat_baseline(box_array, metric):
     plt.plot(x, flat_line, 'r--', label='Baseline (No stresses)')
 
 def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analysis, iterations):
-    OUTPUT_DIRECTORY = '/Users/ayctsai/Desktop/TB_Test/'
+    OUTPUT_DIRECTORY = 'results/'
     causal_output = ''
     if use_causal_analysis:
         causal_output = 'causal'
     else:
         causal_output = 'singlestress'
     output_file_name = '{}_{}_{}_{}.csv'.format(experiment_type, causal_output, iterations, datetime.datetime.now())
+
+    if not os.path.exists(OUTPUT_DIRECTORY):
+        os.makedirs(OUTPUT_DIRECTORY)
 
     with open(OUTPUT_DIRECTORY + output_file_name, 'wb') as csvfile:
         fieldnames = ['service', 'container_id', 'metric', 'increment', 'resource', 'mean', 'stddev', 'data_points']
@@ -130,12 +133,9 @@ def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analy
     return OUTPUT_DIRECTORY + output_file_name
 
 def plot_results(data_file, experiment_type, iterations, should_save, convertToMilli=True, use_causal_analysis=True):
-    fig = plt.figure(1, figsize=(9,6))
-    ax = fig.add_subplot(111)
-
     cpu, disk, network = read_from_file(data_file)
 
-    OUTPUT_DIRECTORY = '/Users/ayctsai/Desktop/TB_Test/graphs/'
+    OUTPUT_DIRECTORY = 'results/graphs/'
     causal_output = ''
     if use_causal_analysis:
         causal_output = 'causal'
@@ -151,6 +151,10 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
     for service, containerd in cpu.iteritems():
         for container, data in containerd.iteritems():
             for metric in data.iterkeys():
+
+                fig = plt.figure(1, figsize=(11,6))
+                ax = fig.add_subplot(111)
+
                 box_array_cpu = []
                 box_array_disk = []
                 box_array_network = []

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -29,12 +29,12 @@ def read_from_file(data_file):
                 disk[service] = {}
                 network[service] = {}
 
-            if container_id not in cpu:
+            if container_id not in cpu[service]:
                 cpu[service][container_id] = {}
                 disk[service][container_id] = {}
                 network[service][container_id] = {}
 
-            if metric not in cpu:
+            if metric not in cpu[service][container_id]:
                 cpu[service][container_id][metric] = {}
                 disk[service][container_id][metric] = {}
                 network[service][container_id][metric] = {}
@@ -64,13 +64,17 @@ def plot_boxplot(axis_labels, box_array, metric, resource_field, subplot_number,
     plt.boxplot(box_array)
     plt.grid(True)
 
-def plot_interpolation(box_array, metric, resource, experiment_type='changeme!'):
+def plot_interpolation(box_array, metric, resource, experiment_type='changeme!', service='changeme!', container_id='changeme!'):
     median_box = [numpy.median(increment_result) for increment_result in box_array]
     x = [0, 20, 40, 60, 80]
+    # x = [0, 50] # TESTING
     std_dev = [numpy.std(increment_result) for increment_result in box_array]
     plt.xlim(-5, 85)
     font = {'family':'serif','serif':['Times']}
-    plt.title('{}'.format(experiment_type), fontname="Times New Roman", size=20)
+    if len(service) < 15:
+        plt.title('Exp: \"{}\" Service: \"{}...\" Container: \"{}\"'.format(experiment_type, service, container_id), fontname="Times New Roman", size=18)
+    else:
+        plt.title('Exp: \"{}\" Service: \"{}...\" Container: \"{}\"'.format(experiment_type, service[:15], container_id), fontname="Times New Roman", size=18)
     plt.ylabel('{} (ms)'.format(metric), fontname="Times New Roman", size=16)
     plt.xlabel('Percentage Resource Stressed', fontname="Times New Roman", size=16)
     if resource == 'CPU':
@@ -96,7 +100,7 @@ def plot_flat_baseline(box_array, metric):
     plt.plot(x, flat_line, 'r--', label='Baseline (No stresses)')
 
 def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analysis, iterations):
-    OUTPUT_DIRECTORY = '/Users/michaelchang/quilt/resource_modification/results/text_results/'
+    OUTPUT_DIRECTORY = '/Users/ayctsai/Desktop/TB_Test/'
     causal_output = ''
     if use_causal_analysis:
         causal_output = 'causal'
@@ -109,19 +113,19 @@ def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analy
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
 
-        for service, (container, data) in disk:
-            #Iterate through the metrics
-            all_metric_keys = data[0].keys()
-            for metric in all_metric_keys:
-                for increment_key in sorted(data.iterkeys()):
-                #Iterate through different metrics
-                    results_cpu = cpu[service][container][increment_key][metric]
-                    results_disk = disk[service][container][increment_key][metric]
-                    results_network = network[service][container][increment_key][metric]
+        for service, containerd in disk.iteritems():
+            for container, data in containerd.iteritems():
+                all_metric_keys = data[0].keys()
+                for metric in all_metric_keys:
+                    for increment_key in sorted(data.iterkeys()):
+                    #Iterate through different metrics
+                        results_cpu = cpu[service][container][increment_key][metric]
+                        results_disk = disk[service][container][increment_key][metric]
+                        results_network = network[service][container][increment_key][metric]
 
-                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'cpu', 'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu), 'data_points': results_cpu})
-                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'disk', 'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk), 'data_points': results_disk})
-                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'network', 'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network), 'data_points': results_network})
+                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'cpu', 'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu), 'data_points': results_cpu})
+                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'disk', 'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk), 'data_points': results_disk})
+                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'network', 'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network), 'data_points': results_network})
 
     return OUTPUT_DIRECTORY + output_file_name
 
@@ -131,7 +135,7 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
 
     cpu, disk, network = read_from_file(data_file)
 
-    OUTPUT_DIRECTORY = '/Users/michaelchang/quilt/resource_modification/results/graphs/'
+    OUTPUT_DIRECTORY = '/Users/ayctsai/Desktop/TB_Test/graphs/'
     causal_output = ''
     if use_causal_analysis:
         causal_output = 'causal'
@@ -143,92 +147,93 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
     if not os.path.exists(OUTPUT_DIRECTORY + output_dir_name):
         os.makedirs(OUTPUT_DIRECTORY + output_dir_name)
 
-    for service,(container,data) in cpu:
-        # Iterate through the metrics
-        for metric in data.iterkeys():
-            box_array_cpu = []
-            box_array_disk = []
-            box_array_network = []
-            axis_labels = []
 
-            baseline_results = numpy.mean(ast.literal_eval(data[metric]['0']))
-            print 'baseline results is {}'.format(baseline_results)
+    for service, containerd in cpu.iteritems():
+        for container, data in containerd.iteritems():
+            for metric in data.iterkeys():
+                box_array_cpu = []
+                box_array_disk = []
+                box_array_network = []
+                axis_labels = []
 
-            for increment_key in sorted(data[metric].iterkeys()):
-                # Iterate through different metrics
-                results_cpu = ast.literal_eval(cpu[service][container][metric][increment_key])
-                results_disk = ast.literal_eval(disk[service][container][metric][increment_key])
-                results_network = ast.literal_eval(network[service][container][metric][increment_key])
+                baseline_results = numpy.mean(ast.literal_eval(data[metric]['0']))
+                print 'baseline results is {}'.format(baseline_results)
 
-                # results_cpu = [result - baseline_results for result in results_cpu]
-                # results_disk = [result - baseline_results for result in results_disk]
-                # results_network = [result - baseline_results for result in results_network]
+                for increment_key in sorted(data[metric].iterkeys()):
+                    # Iterate through different metrics
+                    results_cpu = ast.literal_eval(cpu[service][container][metric][increment_key])
+                    results_disk = ast.literal_eval(disk[service][container][metric][increment_key])
+                    results_network = ast.literal_eval(network[service][container][metric][increment_key])
 
-                print '==========================================================='
-                print 'FOR CONTAINER {} OF SERVICE {}'.format(container, service)
-                print 'THE METRIC IS: {}'.format(metric)
-                print 'For Key: {}'.format(increment_key)
-                print 'CPU stats:'
-                print 'Mean: {}'.format(numpy.mean(results_cpu))
-                print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
+                    # results_cpu = [result - baseline_results for result in results_cpu]
+                    # results_disk = [result - baseline_results for result in results_disk]
+                    # results_network = [result - baseline_results for result in results_network]
 
-                print 'Disk Stats: '
-                print 'Mean: {}'.format(numpy.mean(results_disk))
-                print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
+                    print '==========================================================='
+                    print 'FOR CONTAINER {} OF SERVICE {}'.format(container, service)
+                    print 'THE METRIC IS: {}'.format(metric)
+                    print 'For Key: {}'.format(increment_key)
+                    print 'CPU stats:'
+                    print 'Mean: {}'.format(numpy.mean(results_cpu))
+                    print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
 
-                print 'Network Stats: '
-                print 'Mean: {}'.format(numpy.mean(results_network))
-                print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
+                    print 'Disk Stats: '
+                    print 'Mean: {}'.format(numpy.mean(results_disk))
+                    print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
 
-                axis_labels.append(increment_key)
-                try:
-                    temp_array_cpu = numpy.array(results_cpu)
-                    # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
-                    box_array_cpu.append(temp_array_cpu)
-                except:
-                    print 'CPU FAILED'
+                    print 'Network Stats: '
+                    print 'Mean: {}'.format(numpy.mean(results_network))
+                    print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
 
-                try:
-                    temp_array_disk = numpy.array(results_disk)
-    #                no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
-                    box_array_disk.append(temp_array_disk)
-                except:
-                    print 'DISK FAILED'
+                    axis_labels.append(increment_key)
+                    try:
+                        temp_array_cpu = numpy.array(results_cpu)
+                        # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
+                        box_array_cpu.append(temp_array_cpu)
+                    except:
+                        print 'CPU FAILED'
 
-                try:
-                    temp_array_network = numpy.array(results_network)
-    #                no_outliers_network = temp_array_network[~is_outlier(results_network)]
-                    box_array_network.append(temp_array_network)
-                except:
-                    print 'NETWORK FAILED'
+                    try:
+                        temp_array_disk = numpy.array(results_disk)
+                        # no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
+                        box_array_disk.append(temp_array_disk)
+                    except:
+                        print 'DISK FAILED'
 
-            ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
-            ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
+                    try:
+                        temp_array_network = numpy.array(results_network)
+                        # no_outliers_network = temp_array_network[~is_outlier(results_network)]
+                        box_array_network.append(temp_array_network)
+                    except:
+                        print 'NETWORK FAILED'
 
-            # Plots the boxplots
-            # plot_boxplot(axis_labels, box_array_disk, metric, 'Disk', 222, use_causal_analysis, ymin, ymax)
-            # plot_boxplot(axis_labels, box_array_network, metric, 'Network', 221, use_causal_analysis, ymin, ymax)
-            # plot_boxplot(axis_labels, box_array_cpu, metric, 'CPU', 223, use_causal_analysis, ymin, ymax)
+                ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
+                ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
 
-            # Plots through the medians
-            plot_interpolation(box_array_disk, metric, 'Disk')
-            plot_interpolation(box_array_network, metric, 'Network')
-            plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type)
+                # Plots the boxplots
+                # plot_boxplot(axis_labels, box_array_disk, metric, 'Disk', 222, use_causal_analysis, ymin, ymax)
+                # plot_boxplot(axis_labels, box_array_network, metric, 'Network', 221, use_causal_analysis, ymin, ymax)
+                # plot_boxplot(axis_labels, box_array_cpu, metric, 'CPU', 223, use_causal_analysis, ymin, ymax)
 
-            plot_flat_baseline(box_array_disk, metric)
+                # Plots through the medians
+                plot_interpolation(box_array_disk, metric, 'Disk')
+                plot_interpolation(box_array_network, metric, 'Network')
+                plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type, service, container)
 
-            plt.legend(loc=(0.05, 0.6))
+                plot_flat_baseline(box_array_disk, metric)
 
-            graph_file = OUTPUT_DIRECTORY + output_dir_name + '/' + metric + '.png'
-            graph_file = './' + output_dir_name +  metric + '.png'
+                plt.legend(loc=(0.05, 0.6))
 
-            print output_dir_name
-            if should_save == 'save_pdf' and metric == 'latency_99':
-                pp = PdfPages(output_dir_name + '.pdf')
-                pp.savefig()
-                pp.close()
-    #        plt.savefig(graph_file)
-            plt.show()
+                graph_file = OUTPUT_DIRECTORY + output_dir_name + '/' + container + metric + '.png'
+                # graph_file = './' + output_dir_name +  metric + '.png'
+
+                print output_dir_name
+                if should_save == 'save_pdf':
+                    pp = PdfPages(output_dir_name + '.pdf')
+                    pp.savefig()
+                    pp.close()
+                plt.savefig(graph_file)
+                plt.show()
 
     return
 
@@ -249,13 +254,12 @@ def find_max_point(results):
     return max_val
 
 
+# Temporary Main function for testing
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("output_file", help="Public IP Address that the measurement module will hit" )
-    parser.add_argument("experiment_type", help="Options: spark-ml-matrix, nginx-single, REST")
-    parser.add_argument("should_save", help="Options: spark-ml-matrix, nginx-single, REST")
+    parser.add_argument("output_file", help="File containing results" )
     args = parser.parse_args()
     print args
     results_in_milli = False
 
-    plot_results(args.output_file, args.experiment_type, -1, args.should_save, convertToMilli=results_in_milli, use_causal_analysis=False)
+    plot_results(args.output_file, 'todo-app', 2, 'save', False, False)

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -17,22 +17,34 @@ def read_from_file(data_file):
     with open(data_file) as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
+            service = row['service']
+            container_id = row['container_id']
             metric = row['metric']
             stress_level = row['increment']
             resource = row['resource']
             results = row['data_points']
 
+            if service not in cpu:
+                cpu[service] = {}
+                disk[service] = {}
+                network[service] = {}
+
+            if container_id not in cpu:
+                cpu[service][container_id] = {}
+                disk[service][container_id] = {}
+                network[service][container_id] = {}
+
             if metric not in cpu:
-                cpu[metric] = {}
-                disk[metric] = {}
-                network[metric] = {}
+                cpu[service][container_id][metric] = {}
+                disk[service][container_id][metric] = {}
+                network[service][container_id][metric] = {}
 
             if resource == 'cpu':
-                cpu[metric][stress_level] = results
+                cpu[service][container_id][metric][stress_level] = results
             elif resource == 'disk':
-                disk[metric][stress_level] = results
+                disk[service][container_id][metric][stress_level] = results
             elif resource == 'network':
-                network[metric][stress_level] = results
+                network[service][container_id][metric][stress_level] = results
 
     return cpu, disk, network
 
@@ -92,24 +104,24 @@ def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analy
         causal_output = 'singlestress'
     output_file_name = '{}_{}_{}_{}.csv'.format(experiment_type, causal_output, iterations, datetime.datetime.now())
 
-    all_metric_keys = disk[0].keys()
-
     with open(OUTPUT_DIRECTORY + output_file_name, 'wb') as csvfile:
-        fieldnames = ['metric', 'increment', 'resource', 'mean', 'stddev', 'data_points']
+        fieldnames = ['service', 'container_id', 'metric', 'increment', 'resource', 'mean', 'stddev', 'data_points']
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
 
-        #Iterate through the metrics
-        for metric in all_metric_keys:
-            for increment_key in sorted(disk.iterkeys()):
+        for service, (container, data) in disk:
+            #Iterate through the metrics
+            all_metric_keys = data[0].keys()
+            for metric in all_metric_keys:
+                for increment_key in sorted(data.iterkeys()):
                 #Iterate through different metrics
-                results_cpu = cpu[increment_key][metric]
-                results_disk = disk[increment_key][metric]
-                results_network = network[increment_key][metric]
+                    results_cpu = cpu[service][container][increment_key][metric]
+                    results_disk = disk[service][container][increment_key][metric]
+                    results_network = network[service][container][increment_key][metric]
 
-                writer.writerow({'metric': metric, 'increment': increment_key, 'resource': 'cpu', 'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu), 'data_points': results_cpu})
-                writer.writerow({'metric': metric, 'increment': increment_key, 'resource': 'disk', 'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk), 'data_points': results_disk})
-                writer.writerow({'metric': metric, 'increment': increment_key, 'resource': 'network', 'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network), 'data_points': results_network})
+                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'cpu', 'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu), 'data_points': results_cpu})
+                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'disk', 'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk), 'data_points': results_disk})
+                    writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'network', 'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network), 'data_points': results_network})
 
     return OUTPUT_DIRECTORY + output_file_name
 
@@ -131,90 +143,92 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
     if not os.path.exists(OUTPUT_DIRECTORY + output_dir_name):
         os.makedirs(OUTPUT_DIRECTORY + output_dir_name)
 
-    # Iterate through the metrics
-    for metric in cpu.iterkeys():
-        box_array_cpu = []
-        box_array_disk = []
-        box_array_network = []
-        axis_labels = []
+    for service,(container,data) in cpu:
+        # Iterate through the metrics
+        for metric in data.iterkeys():
+            box_array_cpu = []
+            box_array_disk = []
+            box_array_network = []
+            axis_labels = []
 
-        baseline_results = numpy.mean(ast.literal_eval(cpu[metric]['0']))
-        print 'baseline results is {}'.format(baseline_results)
+            baseline_results = numpy.mean(ast.literal_eval(data[metric]['0']))
+            print 'baseline results is {}'.format(baseline_results)
 
-        for increment_key in sorted(disk[metric].iterkeys()):
-            # Iterate through different metrics
-            results_cpu = ast.literal_eval(cpu[metric][increment_key])
-            results_disk = ast.literal_eval(disk[metric][increment_key])
-            results_network = ast.literal_eval(network[metric][increment_key])
+            for increment_key in sorted(data[metric].iterkeys()):
+                # Iterate through different metrics
+                results_cpu = ast.literal_eval(cpu[service][container][metric][increment_key])
+                results_disk = ast.literal_eval(disk[service][container][metric][increment_key])
+                results_network = ast.literal_eval(network[service][container][metric][increment_key])
 
-            # results_cpu = [result - baseline_results for result in results_cpu]
-            # results_disk = [result - baseline_results for result in results_disk]
-            # results_network = [result - baseline_results for result in results_network]
+                # results_cpu = [result - baseline_results for result in results_cpu]
+                # results_disk = [result - baseline_results for result in results_disk]
+                # results_network = [result - baseline_results for result in results_network]
 
-            print '==========================================================='
-            print 'THE METRIC IS: {}'.format(metric)
-            print 'For Key: {}'.format(increment_key)
-            print 'CPU stats:'
-            print 'Mean: {}'.format(numpy.mean(results_cpu))
-            print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
+                print '==========================================================='
+                print 'FOR CONTAINER {} OF SERVICE {}'.format(container, service)
+                print 'THE METRIC IS: {}'.format(metric)
+                print 'For Key: {}'.format(increment_key)
+                print 'CPU stats:'
+                print 'Mean: {}'.format(numpy.mean(results_cpu))
+                print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
 
-            print 'Disk Stats: '
-            print 'Mean: {}'.format(numpy.mean(results_disk))
-            print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
+                print 'Disk Stats: '
+                print 'Mean: {}'.format(numpy.mean(results_disk))
+                print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
 
-            print 'Network Stats: '
-            print 'Mean: {}'.format(numpy.mean(results_network))
-            print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
+                print 'Network Stats: '
+                print 'Mean: {}'.format(numpy.mean(results_network))
+                print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
 
-            axis_labels.append(increment_key)
-            try:
-                temp_array_cpu = numpy.array(results_cpu)
-                # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
-                box_array_cpu.append(temp_array_cpu)
-            except:
-                print 'CPU FAILED'
+                axis_labels.append(increment_key)
+                try:
+                    temp_array_cpu = numpy.array(results_cpu)
+                    # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
+                    box_array_cpu.append(temp_array_cpu)
+                except:
+                    print 'CPU FAILED'
 
-            try:
-                temp_array_disk = numpy.array(results_disk)
-#                no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
-                box_array_disk.append(temp_array_disk)
-            except:
-                print 'DISK FAILED'
+                try:
+                    temp_array_disk = numpy.array(results_disk)
+    #                no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
+                    box_array_disk.append(temp_array_disk)
+                except:
+                    print 'DISK FAILED'
 
-            try:
-                temp_array_network = numpy.array(results_network)
-#                no_outliers_network = temp_array_network[~is_outlier(results_network)]
-                box_array_network.append(temp_array_network)
-            except:
-                print 'NETWORK FAILED'
+                try:
+                    temp_array_network = numpy.array(results_network)
+    #                no_outliers_network = temp_array_network[~is_outlier(results_network)]
+                    box_array_network.append(temp_array_network)
+                except:
+                    print 'NETWORK FAILED'
 
-        ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
-        ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
+            ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
+            ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
 
-        # Plots the boxplots
-        # plot_boxplot(axis_labels, box_array_disk, metric, 'Disk', 222, use_causal_analysis, ymin, ymax)
-        # plot_boxplot(axis_labels, box_array_network, metric, 'Network', 221, use_causal_analysis, ymin, ymax)
-        # plot_boxplot(axis_labels, box_array_cpu, metric, 'CPU', 223, use_causal_analysis, ymin, ymax)
+            # Plots the boxplots
+            # plot_boxplot(axis_labels, box_array_disk, metric, 'Disk', 222, use_causal_analysis, ymin, ymax)
+            # plot_boxplot(axis_labels, box_array_network, metric, 'Network', 221, use_causal_analysis, ymin, ymax)
+            # plot_boxplot(axis_labels, box_array_cpu, metric, 'CPU', 223, use_causal_analysis, ymin, ymax)
 
-        # Plots through the medians
-        plot_interpolation(box_array_disk, metric, 'Disk')
-        plot_interpolation(box_array_network, metric, 'Network')
-        plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type)
+            # Plots through the medians
+            plot_interpolation(box_array_disk, metric, 'Disk')
+            plot_interpolation(box_array_network, metric, 'Network')
+            plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type)
 
-        plot_flat_baseline(box_array_disk, metric)
+            plot_flat_baseline(box_array_disk, metric)
 
-        plt.legend(loc=(0.05, 0.6))
+            plt.legend(loc=(0.05, 0.6))
 
-        graph_file = OUTPUT_DIRECTORY + output_dir_name + '/' + metric + '.png'
-        graph_file = './' + output_dir_name +  metric + '.png'
+            graph_file = OUTPUT_DIRECTORY + output_dir_name + '/' + metric + '.png'
+            graph_file = './' + output_dir_name +  metric + '.png'
 
-        print output_dir_name
-        if should_save == 'save_pdf' and metric == 'latency_99':
-            pp = PdfPages(output_dir_name + '.pdf')
-            pp.savefig()
-            pp.close()
-#        plt.savefig(graph_file)
-        plt.show()
+            print output_dir_name
+            if should_save == 'save_pdf' and metric == 'latency_99':
+                pp = PdfPages(output_dir_name + '.pdf')
+                pp.savefig()
+                pp.close()
+    #        plt.savefig(graph_file)
+            plt.show()
 
     return
 

--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -153,7 +153,7 @@ def measure_ml_matrix(container_id, spark_args, experiment_iterations):
 #container_id unused: see note in measure_runtime
 def measure_TODO_response_time(container_id, todo_args, iterations):
     REST_server_ip = todo_args[0]
-    req_generator_ip = todo_args[1]
+    ssh_client = todo_args[1]
 
     all_requests = {}
     all_requests['rps'] = []
@@ -164,17 +164,19 @@ def measure_TODO_response_time(container_id, todo_args, iterations):
 
     dummy_utilizations = {}
 
-    NUM_REQUESTS = 1500
-    CONCURRENCY = 700
+    NUM_REQUESTS = 500
+    CONCURRENCY = 200
     ACCEPTABLE_MS = 60
 
-    ssh_client = quilt_ssh(req_generator_ip)
-    post_cmd = 'ab -p post.txt -T application/json -n {} -c {} -e results_file http://{}/api/todos >output.txt'.format(NUM_REQUESTS, CONCURRENCY, REST_server_ip)
+    post_cmd = 'ab -p post.json -T application/json -n {} -c {} -e results_file http://{}/api/todos > output.txt'.format(NUM_REQUESTS, CONCURRENCY, REST_server_ip)
 
-    clear_cmd = 'python3 clear_entries.py'
+    clear_cmd = 'python3 clear_entries.py {}'.format(REST_server_ip)
+
+    print iterations
 
     for x in range(iterations):
         _, results,_ = ssh_client.exec_command(post_cmd)
+        print post_cmd
         results.read()
 
         rps_cmd = 'cat output.txt | grep \'Requests per second\' | awk {{\'print $4\'}}'

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -1,7 +1,6 @@
 import argparse
 from remote_execution import *
 
-
 ### Functions below are for getting initial container dictionaries
 
 # Function that calls on the correct get_container function based on TYPE
@@ -25,19 +24,20 @@ def get_container_ids_all(vm_ips, services):
         _, stdout2, _ = ssh_client.exec_command(docker_container_cmd)
         container_commands = stdout2.read().splitlines()
         for i in range(len(container_ids)):
-            if (services == '*' or (container_commands[i] in services))
+            if services == '*' or (container_commands[i] in services):
                 container_id_dict[container_commands[i]] = (vm_ip, container_ids[i])
 
     return container_id_dict
+
 
 # Returns a tuple of dictionaries of the services and respective container_ids
 # The first dictionary holds the containers to be Stressed
 def get_container_ids_binary(vm_ips, services):
     container_id_dict = get_container_ids_all(vm_ips, services)
-    stress_dict = dict(container_id_dict.items()[len(container_id_dict)/2:])
-    standby_dict = dict(container_id_dict.items()[:len(container_id_dict)/2])
-    
-    return stress_dict,standby_dict
+    stress_dict1 = dict(container_id_dict.items()[len(container_id_dict)/2:])
+    stress_dict2 = dict(container_id_dict.items()[:len(container_id_dict)/2])
+
+    return stress_dict1,stress_dict2
 
 
 ### Functions below are for updating container dictionaries
@@ -49,29 +49,77 @@ def get_updated_container_ids(old_containers, results, stress_type):
     if stress_type == 'ALL':
         return # Will Implement later
     elif stress_type == 'BINARY':
-        # In this case, old_containers should be a tuple
+        # In this case, old_containers should be a tuple of dictionaries
         return get_updated_container_ids_binary(old_containers, results)
     return
 
 
 # Old_containers MUST be a tuple of dictionaries (2)
 def get_updated_container_ids_binary(old_containers, results):
-    old_stress_dict, old_standby_dict = old_containers
-    if (True): # Results indicate stress
-        stress_dict = dict(old_stress_dict.items()[len(old_stress_dict)/2:])
-        standby_dict = dict(old_stress_dict.items()[:len(old_stress_dict)/2])
+    old_stress_dict1, old_stress_dict2 = old_containers
+    results1, results2 = results
+
+    # Check if iteration ends
+    len1 = len(old_stress_dict1)
+    len2 = len(old_stress_dict2)
+    if (len1 == 1 and len2 == 0) or (len1 == 0 and len2 == 1):
+        return None
+
+    if compare_performance_binary(results1, results2): # Results indicate stress
+        stress_dict1 = dict(old_stress_dict1.items()[len(old_stress_dict1)/2:])
+        stress_dict2 = dict(old_stress_dict1.items()[:len(old_stress_dict1)/2])
     else:
-        stress_dict = dict(old_standby_dict.items()[len(old_standby_dict)/2:])
-        standby_dict = dict(old_standby_dict.items()[:len(old_standby_dict)/2])
+        stress_dict1 = dict(old_stress_dict2.items()[len(old_stress_dict2)/2:])
+        stress_dict2 = dict(old_stress_dict2.items()[:len(old_stress_dict2)/2])
 
-    return stress_dict,standby_dict
+    return stress_dict1,stress_dict2
 
-# Temporary main method to test get_container_ids function (NOT UPDATED)
+
+# Returns true if the first set of results perform worse than the second
+# Results1,2 must be a tuple (3)!
+# This method should only be used for stress search type BINARY
+# NOTE: Only considering the results from increment 50 for experimental purposes
+def compare_performance_binary(results1, results2):
+    results_cpu1, results_disk1, results_net1 = results1
+    results_cpu2, results_disk2, results_net2 = results2
+    results_list = [results_cpu1, results_disk1, results_net1, results_cpu2, results_disk2, results_net2]
+
+    # avg_result defined this way to facilitate understanding (instead of just creating an arrays of 0's)
+    avg_cpu1 = avg_cpu2 = avg_disk1 = avg_disk2 = avg_net1 = avg_net2 = 0
+    avg_result = [avg_cpu1, avg_disk1, avg_net1, avg_cpu2, avg_disk2, avg_net2]
+
+    # Shortened from having 6 separate for-loops
+    index = 0
+    for result_type in results_list:
+        sum_50 = count_50 = baseline = 0
+        for service, (container, (increment, delay)) in result_type:
+            if increment == 0:
+                baseline = delay
+            else:
+                sum_50 += baseline - delay
+                count_50 += 1
+        avg_result[index] = sum_50 / float(count_50)
+        index += 1
+
+    # Determining if results1 shows worse performance than results2
+    degradation_points = 0
+    # Comparing each category (CPU, DISK, NET) of result1 to result2
+    index = 0
+    while index < 3:
+        if avg_result[index] > avg_result[3 + index]:
+            degradation_points += 1
+        index += 1
+
+    return degradation_points >= 2
+
+
+# Temporary main method to test get_container_ids function
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("public_vm_ips")
     parser.add_argument("--services_to_stress", help="List of services to stress on machines")
     parser.add_argument("--stress_all_services", action="store_true", help="Stress all services")
+    parser.add_argument("--stress_search_type", help="Type of stress search")
     args = parser.parse_args()
 
     public_vm_ips = args.public_vm_ips.split(',')
@@ -85,9 +133,25 @@ if __name__ == "__main__":
     else:
         services = args.services_to_stress.split(',')
 
-    container_id_dict = get_container_ids(public_vm_ips, services)
+    container_id_dict = get_container_ids(public_vm_ips, services, 'ALL')
+
+    print 'All'
 
     for service, (vm_ip, container_id) in container_id_dict.iteritems():
+        print '{}, ({},{})'.format(service, vm_ip, container_id)
+
+    container_id_dict_tuple = get_container_ids(public_vm_ips, services, 'BINARY')
+
+    container_id_dict,standby_dict = container_id_dict_tuple
+
+    print 'First Half'
+
+    for service, (vm_ip, container_id) in container_id_dict.iteritems():
+        print '{}, ({},{})'.format(service, vm_ip, container_id)
+
+    print 'Second Half'
+
+    for service, (vm_ip, container_id) in standby_dict.iteritems():
         print '{}, ({},{})'.format(service, vm_ip, container_id)
 
     print 'Finished'

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -4,7 +4,8 @@ import remote_execution as remote_exec
 from random import shuffle
 
 ### Pre-defined blacklist (Temporary)
-blacklist = []
+blacklist = ['run ovn-controller','/usr/bin/cadvisor -logtostderr --storage_duration=5m0s --allow_dynamic_housekeeping=true --global_housekeeping_interval=3m0s --housekeeping_interval=1s',
+            '/usr/local/bin/etcd --initial-cluster=master-172.31.15.173=http://172.31.15.173:2380 --heartbeat-interval=500 --election-timeout=5000 --proxy=on', 'run ovs-vswitchd', 'run ovsdb-server', 'quilt -l info minion -role=Worker']
 
 ### Functions below are for getting initial container dictionaries
 
@@ -92,7 +93,7 @@ def get_container_ids_halving(vm_ips, services, resources):
 #     results of the stress tests
 def get_updated_container_ids(old_containers, results, stress_policy):
     if stress_policy == 'ALL':
-        return # Will Implement later
+        return None
     elif stress_policy == 'BINARY' or stress_policy == 'HALVING':
         # In this case, old_containers should be a tuple of dictionaries
         return get_updated_container_ids_binary_halving(old_containers, results)

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -1,11 +1,24 @@
+import argparse
 from remote_execution import *
 
 
 # Returns a dictionary of the services and their respective container_ids
 # VM_IPS is a list of ip addresses, and SERVICES is a list of services
 def get_container_ids(vm_ips, services):
+    container_id_dict = {}
+    for vm_ip in vm_ips:
+        ssh_client = quilt_ssh(vm_ip)
+        docker_container_id = 'docker ps | tr -s \' \' | cut -d \' \' -f1 | tail -n +2'
+        docker_container_cmd = 'docker ps --no-trunc | grep -oP \'\"\K[^\"]+(?=[\"])\''
+        _, stdout1, _ = ssh_client.exec_command(docker_container_id)
+        container_ids = stdout1.read().splitlines()
+        _, stdout2, _ = ssh_client.exec_command(docker_container_cmd)
+        container_commands = stdout2.read().splitlines()
+        for i in range(len(container_ids)):
+            if (services == '*' or (container_commands[i] in services))
+                container_id_dict[container_commands[i]] = (vm_ip, container_ids[i])
 
-    return
+    return container_id_dict
 
 
 # Returns an updated dictionary of the containers to stress
@@ -14,3 +27,30 @@ def get_container_ids(vm_ips, services):
 def get_updated_container_ids(old_containers, results):
     # Will implement later
     return
+
+
+# Temporary main method to test get_container_ids function
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("public_vm_ips")
+    parser.add_argument("--services_to_stress", help="List of services to stress on machines")
+    parser.add_argument("--stress_all_services", action="store_true", help="Stress all services")
+    args = parser.parse_args()
+
+    public_vm_ips = args.public_vm_ips.split(',')
+
+    if (not args.services_to_stress and not args.stress_all_services):
+        print 'Please specify the services to stress'
+        exit()
+
+    if args.stress_all_services:
+        services = '*'
+    else:
+        services = args.services_to_stress.split(',')
+
+    container_id_dict = get_container_ids(public_vm_ips, services)
+
+    for service, (vm_ip, container_id) in container_id_dict.iteritems():
+        print '{}, ({},{})'.format(service, vm_ip, container_id)
+
+    print 'Finished'

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -2,9 +2,19 @@ import argparse
 from remote_execution import *
 
 
+### Functions below are for getting initial container dictionaries
+
+# Function that calls on the correct get_container function based on TYPE
+def get_container_ids(vm_ips, services, stress_type):
+    if stress_type == 'ALL':
+        return get_container_ids_all(vm_ips, services)
+    elif stress_type == 'BINARY':
+        return get_container_ids_binary(vm_ips, services)
+
+
 # Returns a dictionary of the services and their respective container_ids
 # VM_IPS is a list of ip addresses, and SERVICES is a list of services
-def get_container_ids(vm_ips, services):
+def get_container_ids_all(vm_ips, services):
     container_id_dict = {}
     for vm_ip in vm_ips:
         ssh_client = quilt_ssh(vm_ip)
@@ -20,16 +30,43 @@ def get_container_ids(vm_ips, services):
 
     return container_id_dict
 
+# Returns a tuple of dictionaries of the services and respective container_ids
+# The first dictionary holds the containers to be Stressed
+def get_container_ids_binary(vm_ips, services):
+    container_id_dict = get_container_ids_all(vm_ips, services)
+    stress_dict = dict(container_id_dict.items()[len(container_id_dict)/2:])
+    standby_dict = dict(container_id_dict.items()[:len(container_id_dict)/2])
+    
+    return stress_dict,standby_dict
 
-# Returns an updated dictionary of the containers to stress
+
+### Functions below are for updating container dictionaries
+
+# Returns an updated dictionary of the containers to stress based on type
 # OLD_CONTAINERS is the previous dictionary of containers, and RESULTS are the
 #     results of the stress tests
-def get_updated_container_ids(old_containers, results):
-    # Will implement later
+def get_updated_container_ids(old_containers, results, stress_type):
+    if stress_type == 'ALL':
+        return # Will Implement later
+    elif stress_type == 'BINARY':
+        # In this case, old_containers should be a tuple
+        return get_updated_container_ids_binary(old_containers, results)
     return
 
 
-# Temporary main method to test get_container_ids function
+# Old_containers MUST be a tuple of dictionaries (2)
+def get_updated_container_ids_binary(old_containers, results):
+    old_stress_dict, old_standby_dict = old_containers
+    if (True): # Results indicate stress
+        stress_dict = dict(old_stress_dict.items()[len(old_stress_dict)/2:])
+        standby_dict = dict(old_stress_dict.items()[:len(old_stress_dict)/2])
+    else:
+        stress_dict = dict(old_standby_dict.items()[len(old_standby_dict)/2:])
+        standby_dict = dict(old_standby_dict.items()[:len(old_standby_dict)/2])
+
+    return stress_dict,standby_dict
+
+# Temporary main method to test get_container_ids function (NOT UPDATED)
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("public_vm_ips")

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -1,0 +1,16 @@
+from remote_execution import *
+
+
+# Returns a dictionary of the services and their respective container_ids
+# VM_IPS is a list of ip addresses, and SERVICES is a list of services
+def get_container_ids(vm_ips, services):
+
+    return
+
+
+# Returns an updated dictionary of the containers to stress
+# OLD_CONTAINERS is the previous dictionary of containers, and RESULTS are the
+#     results of the stress tests
+def get_updated_container_ids(old_containers, results):
+    # Will implement later
+    return

--- a/src/stress_scheduler.py
+++ b/src/stress_scheduler.py
@@ -265,61 +265,64 @@ def model_machine(container_ids_dict, experiment_args, experiment_iterations, ex
 
                 print 'Experiment with increment={}'.format(increment)
 
-                print '====================================='
-                print 'INITIATING CPU Experiment'
-                num_full_disk = 0
-                if use_causal_analysis:
-                    disk_throttle_rate = weighting_to_disk_access_rate(increment)
-                    container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
-                    network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
-                    start_causal_cpu(ssh_client, container_id, disk_throttle_rate, network_reduction_rate)
-                else:
-                    cpu_throttle_quota = weighting_to_cpu_quota(increment)
-                    throttle_cpu(ssh_client, container_id, 1000000, cpu_throttle_quota)
-                results_data_cpu, cpu_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
-                if use_causal_analysis:
-                    stop_causal_cpu(ssh_client, container_id)
-                else:
-                    stop_throttle_cpu(ssh_client, container_id)
-                reduction_level_to_latency_cpu_container[increment] = results_data_cpu
-                reduction_level_to_utilization_cpu_container[increment] = cpu_utilization_diff
+                if 'CPU' in resources:
+                    print '====================================='
+                    print 'INITIATING CPU Experiment'
+                    num_full_disk = 0
+                    if use_causal_analysis:
+                        disk_throttle_rate = weighting_to_disk_access_rate(increment)
+                        container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
+                        network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
+                        start_causal_cpu(ssh_client, container_id, disk_throttle_rate, network_reduction_rate)
+                    else:
+                        cpu_throttle_quota = weighting_to_cpu_quota(increment)
+                        throttle_cpu(ssh_client, container_id, 1000000, cpu_throttle_quota)
+                    results_data_cpu, cpu_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
+                    if use_causal_analysis:
+                        stop_causal_cpu(ssh_client, container_id)
+                    else:
+                        stop_throttle_cpu(ssh_client, container_id)
+                    reduction_level_to_latency_cpu_container[increment] = results_data_cpu
+                    reduction_level_to_utilization_cpu_container[increment] = cpu_utilization_diff
 
-                print '======================================'
-                print 'INITIATING Network Experiment'
-                if use_causal_analysis:
-                    disk_throttle_rate = weighting_to_disk_access_rate(increment)
-                    cpu_throttle_quota = weighting_to_cpu_quota(increment)
-                    start_causal_network(ssh_client, container_id, 1000000, cpu_throttle_quota, disk_throttle_rate)
-                else:
-                    container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
-                    network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
-                    throttle_network(ssh_client, network_reduction_rate)
-                results_data_network, network_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
+                if 'NET' in resources:
+                    print '======================================'
+                    print 'INITIATING Network Experiment'
+                    if use_causal_analysis:
+                        disk_throttle_rate = weighting_to_disk_access_rate(increment)
+                        cpu_throttle_quota = weighting_to_cpu_quota(increment)
+                        start_causal_network(ssh_client, container_id, 1000000, cpu_throttle_quota, disk_throttle_rate)
+                    else:
+                        container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
+                        network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
+                        throttle_network(ssh_client, network_reduction_rate)
+                    results_data_network, network_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
 
-                if use_causal_analysis:
-                    stop_causal_network(ssh_client, container_id)
-                else:
-                    stop_throttle_network(ssh_client)
-                reduction_level_to_latency_network_container[increment] = results_data_network
-                reduction_level_to_utilization_network_container[increment] = network_utilization_diff
+                    if use_causal_analysis:
+                        stop_causal_network(ssh_client, container_id)
+                    else:
+                        stop_throttle_network(ssh_client)
+                    reduction_level_to_latency_network_container[increment] = results_data_network
+                    reduction_level_to_utilization_network_container[increment] = network_utilization_diff
 
-                print '======================================='
-                print 'INITIATING Disk Experiment '
-                if use_causal_analysis:
-                    cpu_throttle_quota = weighting_to_cpu_quota(increment)
-                    container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
-                    network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
-                    start_causal_disk(ssh_client, container_id, 1000000, cpu_throttle_quota, network_reduction_rate)
-                else:
-                    disk_throttle_rate = weighting_to_disk_access_rate(increment)
-                    throttle_disk(ssh_client, container_id, disk_throttle_rate)
-                results_data_disk, disk_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
-                if use_causal_analysis:
-                    stop_causal_disk(ssh_client, container_id)
-                else:
-                    stop_throttle_disk(ssh_client, container_id)
-                reduction_level_to_latency_disk_container[increment] = results_data_disk
-                reduction_level_to_utilization_disk_container[incremet] = disk_utilization_diff
+                if 'DISK' in resources:
+                    print '======================================='
+                    print 'INITIATING Disk Experiment '
+                    if use_causal_analysis:
+                        cpu_throttle_quota = weighting_to_cpu_quota(increment)
+                        container_to_network_capacity = get_container_network_capacity(ssh_client, container_id)
+                        network_reduction_rate = weighting_to_bandwidth(ssh_client, increment, container_to_network_capacity)
+                        start_causal_disk(ssh_client, container_id, 1000000, cpu_throttle_quota, network_reduction_rate)
+                    else:
+                        disk_throttle_rate = weighting_to_disk_access_rate(increment)
+                        throttle_disk(ssh_client, container_id, disk_throttle_rate)
+                    results_data_disk, disk_utilization_diff = measure_runtime(container_id, experiment_args, experiment_iterations, experiment_type)
+                    if use_causal_analysis:
+                        stop_causal_disk(ssh_client, container_id)
+                    else:
+                        stop_throttle_disk(ssh_client, container_id)
+                    reduction_level_to_latency_disk_container[increment] = results_data_disk
+                    reduction_level_to_utilization_disk_container[incremet] = disk_utilization_diff
 
             reduction_level_to_latency_network_service[container] = reduction_level_to_latency_network_container
             reduction_level_to_latency_disk_service[container] = reduction_level_to_latency_disk_container
@@ -365,6 +368,7 @@ if __name__ == "__main__":
     parser.add_argument("--stress_all_services", action="store_true", help="Stress all services")
     parser.add_argument("--resources_to_stress", help="List of resources to throttle")
     parser.add_argument("--stress_all_resources", action="store_true", help="Throttle all resources")
+    parser.add_argument("--stress_search_type", help="Type of stress search")
     parser.add_argument("--iterations", type=int, default=10, help="Number of HTTP requests to send the REST server per experiment")
     parser.add_argument("--use_causal_analysis", action="store_true", help="Set this option to stress only a single variable")
     parser.add_argument("--only_baseline", action="store_true", help="Only takes a measurement of the baseline without any stress")
@@ -381,18 +385,23 @@ if __name__ == "__main__":
     if args.stress_all_services:
         services = '*'
     else:
-        services = args.services_to_stress
+        services = args.services_to_stress.split(',')
     if args.stress_all_resources:
         resources = ['CPU', 'NET', 'DISK']
     else:
-        resources = args.resources_to_stress
+        resources = args.resources_to_stress.split(',')
 
     # Retrieving dictionary of container_ids with service names as keys
-    container_ids_dict = get_container_ids(args.victim_machine_public_ip, services)
+    container_ids_dict = get_container_ids(args.victim_machine_public_ip.split(','), services, args.stress_search_type)
 
     results_disk = {}
     results_cpu = {}
     results_network = {}
+
+    # Checking for stress search type
+    if args.stress_search_type == 'BINARY':
+        container_ids_tuple = container_ids_dict
+        container_ids_dict, standby_dict = container_ids_dict
 
     # MESSY TODO: Write an abstract class for the experiment type and implement elsewhere
     if args.experiment_type == 'REST':
@@ -420,8 +429,12 @@ if __name__ == "__main__":
     if args.experiment_type == 'spark-ml-matrix' or args.experiment_type == 'nginx-single':
         results_in_milli = False
 
-    # Update container dictionary
-    container_ids_dict = get_updated_container_ids(container_ids_dict, (results_cpu, results_network, results_disk))
+    # Revert container_ids_dict if necessary (Allows for modular update function)
+    if args.stress_search_type == 'BINARY':
+        container_ids_dict = container_ids_tuple
+
+    # Update container dictionary based on type
+    container_ids_dict = get_updated_container_ids(container_ids_dict, (results_cpu, results_network, results_disk), args.stress_search_type)
 
     #Create loop until finished (Undecided)
 

--- a/src/stress_scheduler.py
+++ b/src/stress_scheduler.py
@@ -435,9 +435,9 @@ if __name__ == "__main__":
         else: # More will be added as more search types are implemented
             results_cpu, results_disk, results_network = model_machine(container_ids_dict, experiment_args, args.iterations, args.experiment_type, args.use_causal_analysis, args.only_baseline)
 
-        # TODO: Fix to accomodate for dictionary
         if args.experiment_type == 'REST':
-            reset_experiment(args.victim_machine, None) # args.container_id
+            for service, (vm_ip, container_id) in container_ids_dict:
+                reset_experiment(vm_ip, container_id)
 
         results_in_milli = True
         if args.experiment_type == 'spark-ml-matrix' or args.experiment_type == 'nginx-single':

--- a/src/stress_scheduler.py
+++ b/src/stress_scheduler.py
@@ -60,9 +60,9 @@ def stop_throttle_cpu(ssh_client, container_id):
     print 'RESETTING CPU THROTTLING'
     reset_cpu_quota(ssh_client, container_id)
 
-def stop_throttle_network(ssh_client):
+def stop_throttle_network(ssh_client, container_id):
     print 'RESETTING NETWORK THROTTLING'
-    remove_all_network_manipulation(ssh_client)
+    remove_all_network_manipulation(ssh_client, container_id)
 
 def stop_throttle_disk(ssh_client, container_id):
     print 'RESETTING DISK THROTTLING'
@@ -73,13 +73,13 @@ def stop_throttle_disk(ssh_client, container_id):
 
 def stop_causal_cpu(ssh_client, container_id):
     print 'RESETTING CASUAL CPU!'
-    stop_throttle_network(ssh_client)
+    stop_throttle_network(ssh_client, container_id)
     stop_throttle_disk(ssh_client, container_id)
     sleep(COMMAND_DELAY)
 
 def stop_causal_disk(ssh_client, container_id):
     print 'RESETTING CASUAL DISK!'
-    stop_throttle_network(ssh_client)
+    stop_throttle_network(ssh_client, container_id)
     stop_throttle_cpu(ssh_client, container_id)
     sleep(COMMAND_DELAY)
 
@@ -93,7 +93,7 @@ def reset_all_stresses(ssh_client, container_id):
     print 'RESETTING ALL STRESSES!'
     stop_throttle_cpu(ssh_client, container_id)
     stop_throttle_disk(ssh_client, container_id)
-    stop_throttle_network(ssh_client)
+    stop_throttle_network(ssh_client, container_id)
     sleep(COMMAND_DELAY)
 
 # Removes outlier points from the plot
@@ -192,7 +192,7 @@ def binary_search(parameter_list, field, acceptable_latency_lb, acceptable_laten
         print 'With stress, the mean is {}'.format(mean)
 
         if field == 'network':
-            stop_throttle_network(ssh_client)
+            stop_throttle_network(ssh_client, container_id)
         elif field == 'disk':
             stop_throttle_disk(ssh_client, num_disk_eaters)
         elif field == 'cpu':
@@ -302,7 +302,7 @@ def model_machine(container_ids_dict, experiment_args, experiment_iterations, ex
                     if use_causal_analysis:
                         stop_causal_network(ssh_client, container_id)
                     else:
-                        stop_throttle_network(ssh_client)
+                        stop_throttle_network(ssh_client, container_id)
                     reduction_level_to_latency_network_container[increment] = results_data_network
                     reduction_level_to_utilization_network_container[increment] = network_utilization_diff
 

--- a/src/weighting_conversions.py
+++ b/src/weighting_conversions.py
@@ -10,16 +10,16 @@ def weighting_to_latency(weighting):
     return (weighting / 100.0) * MAX_LATENCY
 
 ###Possible substitute using network bandwidth throttling instead of latency values
-###Returns the throttled bandwidth to Mbit/sec
+###Returns the throttled bandwidth to bits/sec
 def weighting_to_bandwidth(ssh_client, weighting, container_to_capacity):
     if weighting < 0 or weighting > 100:
         print 'Invalid Weighting'
         return
 
-    #Convert to stress amount AND convert from Mbps to Kbps
+    #Convert to stress amount AND convert from Mbps to bps
     for container in container_to_capacity:
         reduction = 100 - weighting
-        container_to_capacity[container] = container_to_capacity[container] * (float(reduction) / 100) * 1000
+        container_to_capacity[container] = container_to_capacity[container] * reduction / 100 * 1000000
 
     return container_to_capacity
 

--- a/src/weighting_conversions.py
+++ b/src/weighting_conversions.py
@@ -40,13 +40,15 @@ def weighting_to_disk_access_rate(weighting):
     #INTRA-VM
     MAX_DISK_READ = 70000000
 
-    return int(MAX_DISK_READ * weighting / 100)
+    reduced = 100 - weighting
+    return int(MAX_DISK_READ * reduced / 100)
 
 def weighting_to_cpu_quota(weighting):
     if weighting < 0 or weighting > 100:
         print ('Invalid Weighting')
         return
-    return int(1000000 * weighting / 100)
+    reduced = 100 - weighting
+    return int(1000000 * reduced / 100)
 
 def weighting_to_cpu_period(weighting):
     weighting = float(100 - weighting)


### PR DESCRIPTION
Main modification was the addition of stress_analyzer. This file is designed to determine the set of containers to stress for the next iteration. So far, the ALL and HALVING stressing policy have been implemented. The ALL policy stresses all services and containers and returns the latency from each stress. The HALVING policy compares the performances of two sets of containers (input) and will return two sets of containers that were split from the worse-performing set of the input. The sets of containers are inputted into stress_scheduler to be stressed, and the results are then fed back into stress_analyzer. This PR also includes general bug fixes and modifications to allow for compatibility for running the todo-app experiment.