### PR TITLE
Core Pinning + Specifying Increments + Checkpoint + Resuming Experiment + Other Fixes

### DIFF
--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -56,7 +56,7 @@ def set_egress_network_bandwidth(ssh_client, container_id, bandwidth):
         print 'ERROR MESSAGE: {}'.format(err_val_rate)
         raise SystemError('Network Set Error')
     else:
-        print 'SUCCESS: Stress of container id {} stressed to {}'.format(container_id, bandwidth)
+        print 'SUCCESS: Network stress of container id {} stressed to {}'.format(container_id, bandwidth)
         return 1
 
 def reset_egress_network_bandwidth(ssh_client, container_id):
@@ -72,7 +72,7 @@ def reset_egress_network_bandwidth(ssh_client, container_id):
         print 'ERROR MESSAGE: {}'.format(err_val_rate)
         raise SystemError('Network Set Error')
     else:
-        print 'SUCCESS: Stress of container id {} removed'.format(container_id)
+        print 'SUCCESS: Network stress of container id {} removed'.format(container_id)
         return 1
 
 # Unused
@@ -133,7 +133,7 @@ def set_cpu_cores(ssh_client, container_id, cores):
     reset_cpu_quota(ssh_client, container_id) # CPU quotas conflict with core pinning
     rst_cores_cmd = 'docker update --cpuset-cpus={} --cpuset-mems=0 {}'.format(cores, container_id)
     ssh_exec(ssh_client, rst_cores_cmd)
-    print 'Cores {} pinned to container {}'.format(cores, container_id)
+    print '{} Cores pinned to container {}'.format(cores, container_id)
 
 
 # Resetting pinned cpu_cores (container will have access to all cores)
@@ -198,8 +198,8 @@ def change_container_blkio(ssh_client, container_id, disk_bandwidth):
     ssh_exec(ssh_client, set_cgroup_write_rate_cmd)
     ssh_exec(ssh_client, set_cgroup_read_rate_cmd)
 
-    # Sleep 10 seconds since the current queue must be emptied before this can be fulfilled
-    sleep(10)
+    # Sleep 5 seconds since the current queue must be emptied before this can be fulfilled
+    sleep(5)
 
 # LEGACY (All functions that creates dummpy containers are legacy and kept for reference)
 # This is a dummy container that eats an arbitrary amount of Disk atthe cost of some CPU utilization

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -66,8 +66,8 @@ def plot_boxplot(axis_labels, box_array, metric, resource_field, subplot_number,
 
 def plot_interpolation(box_array, metric, resource, experiment_type='changeme!', service='changeme!', container_id='changeme!'):
     median_box = [numpy.median(increment_result) for increment_result in box_array]
-    # x = [0, 20, 40, 60, 80]
-    x = [0, 50] # TESTING
+    x = [0, 20, 40, 60, 80]
+    # x = [0, 50] # TESTING
     std_dev = [numpy.std(increment_result) for increment_result in box_array]
     plt.xlim(-5, 85)
     font = {'family':'serif','serif':['Times']}
@@ -115,7 +115,16 @@ def append_results_to_file(cpu, disk, network, resources, experiment_type, use_c
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
 
-        for service, containerd in disk.iteritems():
+        # Checking for used resource
+        base = None
+        if 'CPU' in resources:
+            base = cpu
+        elif 'NET' in resources:
+            base = network
+        elif 'DISK' in resources:
+            base = disk
+
+        for service, containerd in base.iteritems():
             for container, data in containerd.iteritems():
                 all_metric_keys = data[0].keys()
                 for metric in all_metric_keys:
@@ -248,10 +257,10 @@ def plot_results(data_file, resources, experiment_type, iterations, should_save,
 
                 # Plots through the medians
                 if 'DISK' in resources:
-                    plot_interpolation(box_array_disk, metric, 'Disk')
+                    plot_interpolation(box_array_disk, metric, 'Disk', experiment_type, service, container)
                     plot_flat_baseline(box_array_disk, metric)
                 if 'NET' in resources:
-                    plot_interpolation(box_array_network, metric, 'Network')
+                    plot_interpolation(box_array_network, metric, 'Network', experiment_type, service, container)
                     plot_flat_baseline(box_array_network, metric)
                 if 'CPU' in resources:
                     plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type, service, container)

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -66,8 +66,8 @@ def plot_boxplot(axis_labels, box_array, metric, resource_field, subplot_number,
 
 def plot_interpolation(box_array, metric, resource, experiment_type='changeme!', service='changeme!', container_id='changeme!'):
     median_box = [numpy.median(increment_result) for increment_result in box_array]
-    x = [0, 20, 40, 60, 80]
-    # x = [0, 50] # TESTING
+    # x = [0, 20, 40, 60, 80]
+    x = [0, 50] # TESTING
     std_dev = [numpy.std(increment_result) for increment_result in box_array]
     plt.xlim(-5, 85)
     font = {'family':'serif','serif':['Times']}
@@ -89,7 +89,6 @@ def plot_interpolation(box_array, metric, resource, experiment_type='changeme!',
     line, = plt.plot(x, median_box, lw=3, label=resource, color=line_color)
     # plt.legend(handles=[line])
     plt.errorbar(x, median_box, std_dev, lw=error_length, color=line_color)
-    plt.grid()
     return line
 
 def plot_flat_baseline(box_array, metric):
@@ -99,7 +98,7 @@ def plot_flat_baseline(box_array, metric):
     flat_line = [median] * 5
     plt.plot(x, flat_line, 'r--', label='Baseline (No stresses)')
 
-def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analysis, iterations):
+def append_results_to_file(cpu, disk, network, resources, experiment_type, use_causal_analysis, iterations):
     OUTPUT_DIRECTORY = 'results/'
     causal_output = ''
     if use_causal_analysis:
@@ -122,17 +121,28 @@ def append_results_to_file(cpu, disk, network, experiment_type, use_causal_analy
                 for metric in all_metric_keys:
                     for increment_key in sorted(data.iterkeys()):
                     #Iterate through different metrics
-                        results_cpu = cpu[service][container][increment_key][metric]
-                        results_disk = disk[service][container][increment_key][metric]
-                        results_network = network[service][container][increment_key][metric]
-
-                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'cpu', 'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu), 'data_points': results_cpu})
-                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'disk', 'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk), 'data_points': results_disk})
-                        writer.writerow({'service': service, 'container_id': container, 'metric': metric, 'increment': increment_key, 'resource': 'network', 'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network), 'data_points': results_network})
+                        if 'CPU' in resources:
+                            results_cpu = cpu[service][container][increment_key][metric]
+                            writer.writerow({'service': service, 'container_id': container, 'metric': metric,
+                                             'increment': increment_key, 'resource': 'cpu',
+                                             'mean': numpy.mean(results_cpu), 'stddev': numpy.std(results_cpu),
+                                             'data_points': results_cpu})
+                        if 'DISK' in resources:
+                            results_disk = disk[service][container][increment_key][metric]
+                            writer.writerow({'service': service, 'container_id': container, 'metric': metric,
+                                             'increment': increment_key, 'resource': 'disk',
+                                             'mean': numpy.mean(results_disk), 'stddev': numpy.std(results_disk),
+                                             'data_points': results_disk})
+                        if 'NET' in resources:
+                            results_network = network[service][container][increment_key][metric]
+                            writer.writerow({'service': service, 'container_id': container, 'metric': metric,
+                                             'increment': increment_key, 'resource': 'network',
+                                             'mean': numpy.mean(results_network), 'stddev': numpy.std(results_network),
+                                             'data_points': results_network})
 
     return OUTPUT_DIRECTORY + output_file_name
 
-def plot_results(data_file, experiment_type, iterations, should_save, convertToMilli=True, use_causal_analysis=True):
+def plot_results(data_file, resources, experiment_type, iterations, should_save, convertToMilli=True, use_causal_analysis=True):
     cpu, disk, network = read_from_file(data_file)
 
     OUTPUT_DIRECTORY = 'results/graphs/'
@@ -147,8 +157,16 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
     if not os.path.exists(OUTPUT_DIRECTORY + output_dir_name):
         os.makedirs(OUTPUT_DIRECTORY + output_dir_name)
 
+    # Checking for used resource
+    base = None
+    if 'CPU' in resources:
+        base = cpu
+    elif 'NET' in resources:
+        base = network
+    elif 'DISK' in resources:
+        base = disk
 
-    for service, containerd in cpu.iteritems():
+    for service, containerd in base.iteritems():
         for container, data in containerd.iteritems():
             for metric in data.iterkeys():
 
@@ -165,9 +183,12 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
 
                 for increment_key in sorted(data[metric].iterkeys()):
                     # Iterate through different metrics
-                    results_cpu = ast.literal_eval(cpu[service][container][metric][increment_key])
-                    results_disk = ast.literal_eval(disk[service][container][metric][increment_key])
-                    results_network = ast.literal_eval(network[service][container][metric][increment_key])
+                    if 'CPU' in resources:
+                        results_cpu = ast.literal_eval(cpu[service][container][metric][increment_key])
+                    if 'DISK' in resources:
+                        results_disk = ast.literal_eval(disk[service][container][metric][increment_key])
+                    if 'NET' in resources:
+                        results_network = ast.literal_eval(network[service][container][metric][increment_key])
 
                     # results_cpu = [result - baseline_results for result in results_cpu]
                     # results_disk = [result - baseline_results for result in results_disk]
@@ -177,42 +198,48 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
                     print 'FOR CONTAINER {} OF SERVICE {}'.format(container, service)
                     print 'THE METRIC IS: {}'.format(metric)
                     print 'For Key: {}'.format(increment_key)
-                    print 'CPU stats:'
-                    print 'Mean: {}'.format(numpy.mean(results_cpu))
-                    print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
+                    if 'CPU' in resources:
+                        print 'CPU stats:'
+                        print 'Mean: {}'.format(numpy.mean(results_cpu))
+                        print 'Standard Deviation: {}\n'.format(numpy.std(results_cpu))
 
-                    print 'Disk Stats: '
-                    print 'Mean: {}'.format(numpy.mean(results_disk))
-                    print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
+                    if 'DISK' in resources:
+                        print 'Disk Stats: '
+                        print 'Mean: {}'.format(numpy.mean(results_disk))
+                        print 'Standard Deviation: {}\n'.format(numpy.std(results_disk))
 
-                    print 'Network Stats: '
-                    print 'Mean: {}'.format(numpy.mean(results_network))
-                    print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
+                    if 'NET' in resources:
+                        print 'Network Stats: '
+                        print 'Mean: {}'.format(numpy.mean(results_network))
+                        print 'Standard Deviation: {}\n'.format(numpy.std(results_network))
 
                     axis_labels.append(increment_key)
-                    try:
-                        temp_array_cpu = numpy.array(results_cpu)
-                        # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
-                        box_array_cpu.append(temp_array_cpu)
-                    except:
-                        print 'CPU FAILED'
+                    if 'CPU' in resources:
+                        try:
+                            temp_array_cpu = numpy.array(results_cpu)
+                            # no_outliers_cpu = temp_array_cpu[~is_outlier(results_cpu)]
+                            box_array_cpu.append(temp_array_cpu)
+                        except:
+                            print 'CPU FAILED'
 
-                    try:
-                        temp_array_disk = numpy.array(results_disk)
-                        # no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
-                        box_array_disk.append(temp_array_disk)
-                    except:
-                        print 'DISK FAILED'
+                    if 'DISK' in resources:
+                        try:
+                            temp_array_disk = numpy.array(results_disk)
+                            # no_outliers_disk = temp_array_disk[~is_outlier(results_disk)]
+                            box_array_disk.append(temp_array_disk)
+                        except:
+                            print 'DISK FAILED'
 
-                    try:
-                        temp_array_network = numpy.array(results_network)
-                        # no_outliers_network = temp_array_network[~is_outlier(results_network)]
-                        box_array_network.append(temp_array_network)
-                    except:
-                        print 'NETWORK FAILED'
+                    if 'NET' in resources:
+                        try:
+                            temp_array_network = numpy.array(results_network)
+                            # no_outliers_network = temp_array_network[~is_outlier(results_network)]
+                            box_array_network.append(temp_array_network)
+                        except:
+                            print 'NETWORK FAILED'
 
-                ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
-                ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
+                # ymin = 1.05 * min(find_min_point(box_array_cpu), find_min_point(box_array_disk), find_min_point(box_array_network))
+                # ymax = 1.2 * max(find_max_point(box_array_cpu), find_max_point(box_array_disk), find_max_point(box_array_network))
 
                 # Plots the boxplots
                 # plot_boxplot(axis_labels, box_array_disk, metric, 'Disk', 222, use_causal_analysis, ymin, ymax)
@@ -220,13 +247,18 @@ def plot_results(data_file, experiment_type, iterations, should_save, convertToM
                 # plot_boxplot(axis_labels, box_array_cpu, metric, 'CPU', 223, use_causal_analysis, ymin, ymax)
 
                 # Plots through the medians
-                plot_interpolation(box_array_disk, metric, 'Disk')
-                plot_interpolation(box_array_network, metric, 'Network')
-                plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type, service, container)
-
-                plot_flat_baseline(box_array_disk, metric)
+                if 'DISK' in resources:
+                    plot_interpolation(box_array_disk, metric, 'Disk')
+                    plot_flat_baseline(box_array_disk, metric)
+                if 'NET' in resources:
+                    plot_interpolation(box_array_network, metric, 'Network')
+                    plot_flat_baseline(box_array_network, metric)
+                if 'CPU' in resources:
+                    plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type, service, container)
+                    plot_flat_baseline(box_array_cpu, metric)
 
                 plt.legend(loc=(0.05, 0.6))
+                plt.grid()
 
                 graph_file = OUTPUT_DIRECTORY + output_dir_name + '/' + container + metric + '.png'
                 # graph_file = './' + output_dir_name +  metric + '.png'
@@ -262,8 +294,9 @@ def find_max_point(results):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("output_file", help="File containing results" )
+    parser.add_argument("resources_to_stress", help="List of resources to throttle")
     args = parser.parse_args()
     print args
     results_in_milli = False
 
-    plot_results(args.output_file, 'todo-app', 2, 'save', False, False)
+    plot_results(args.output_file, args.resources_to_stress.split(','), 'todo-app', 1, 'save', False, False)

--- a/src/present_results.py
+++ b/src/present_results.py
@@ -98,7 +98,7 @@ def plot_flat_baseline(box_array, metric):
     flat_line = [median] * 5
     plt.plot(x, flat_line, 'r--', label='Baseline (No stresses)')
 
-def append_results_to_file(cpu, disk, network, resources, experiment_type, use_causal_analysis, iterations):
+def append_results_to_file(cpu, disk, network, resources, increments, experiment_type, use_causal_analysis, iterations):
     OUTPUT_DIRECTORY = 'results/'
     causal_output = ''
     if use_causal_analysis:
@@ -126,7 +126,7 @@ def append_results_to_file(cpu, disk, network, resources, experiment_type, use_c
 
         for service, containerd in base.iteritems():
             for container, data in containerd.iteritems():
-                all_metric_keys = data[0].keys()
+                all_metric_keys = data[min(increments)].keys()
                 for metric in all_metric_keys:
                     for increment_key in sorted(data.iterkeys()):
                     #Iterate through different metrics
@@ -258,12 +258,16 @@ def plot_results(data_file, resources, experiment_type, iterations, should_save,
                 # Plots through the medians
                 if 'DISK' in resources:
                     plot_interpolation(box_array_disk, metric, 'Disk', experiment_type, service, container)
-                    plot_flat_baseline(box_array_disk, metric)
                 if 'NET' in resources:
                     plot_interpolation(box_array_network, metric, 'Network', experiment_type, service, container)
-                    plot_flat_baseline(box_array_network, metric)
                 if 'CPU' in resources:
                     plot_interpolation(box_array_cpu, metric, 'CPU', experiment_type, service, container)
+
+                if 'DISK' in resources:
+                    plot_flat_baseline(box_array_disk, metric)
+                elif 'NET' in resources:
+                    plot_flat_baseline(box_array_network, metric)
+                elif 'DISK' in resources:
                     plot_flat_baseline(box_array_cpu, metric)
 
                 plt.legend(loc=(0.05, 0.6))

--- a/src/set_resources.py
+++ b/src/set_resources.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
             except:
                 error_message(line_numb, 'cpu')
                 exit()
-            if cpu_value == 0:
+            if cpu_percentage == 0:
                 reset_cpu_quota(ssh_client, container_id)
             else:
                 set_cpu_cores(ssh_client, container_id, 0)

--- a/src/stress_scheduler.py
+++ b/src/stress_scheduler.py
@@ -271,8 +271,8 @@ def model_machine(ssh_clients, container_ids_dict, experiment_args, experiment_i
             reduction_level_to_utilization_cpu_container = {}
 
             #Take baseline measurements: no perturbations!'''
-            # BASELINE_ITERATIONS = 10
-            BASELINE_ITERATIONS = 1 # For fast Benchmarking
+            BASELINE_ITERATIONS = 10
+            # BASELINE_ITERATIONS = 1 # For fast Benchmarking
             experiment_args[0] = vm_ip
             print 'EX ARG 0 {}'.format(experiment_args[0])
             baseline_runtime_array, baseline_utilization_diff = measure_runtime(container_id, experiment_args, BASELINE_ITERATIONS, experiment_type)
@@ -410,7 +410,7 @@ if __name__ == "__main__":
     parser.add_argument("--stress_all_resources", action="store_true", help="Throttle all resources")
     parser.add_argument("--cpu_cores", action="store_true", help="Use CPU core throttling")
     parser.add_argument("--stress_search_policy", help="Type of stress policy")
-    parser.add_argument("--iterations", type=int, default=1, help="Number of HTTP requests to send the REST server per experiment")
+    parser.add_argument("--iterations", type=int, default=7, help="Number of HTTP requests to send the REST server per experiment")
     parser.add_argument("--use_causal_analysis", action="store_true", help="Set this option to stress only a single variable")
     parser.add_argument("--only_baseline", action="store_true", help="Only takes a measurement of the baseline without any stress")
 

--- a/src/weighting_conversions.py
+++ b/src/weighting_conversions.py
@@ -53,3 +53,13 @@ def weighting_to_cpu_quota(weighting):
 def weighting_to_cpu_period(weighting):
     weighting = float(100 - weighting)
     return weighting/100
+
+def get_num_cores(ssh_client):
+    num_cores_cmd = 'nproc --all'
+    _, stdout, _ = ssh_client.exec_command(num_cores_cmd)
+    return int(stdout.read())
+
+def weighting_to_cpu_cores(ssh_client, weighting):
+    total_cores = get_num_cores(ssh_client)
+    num_cores = int(round(float(total_cores) * (float(100 - weighting) / 100)))
+    return 1 if num_cores == 0 else num_cores


### PR DESCRIPTION
One change was adding the ability to pin different cores to each container as a means of CPU throttling. Additionally, the user can now specify the stressing increments for the experiment. A checkpoint feature was also added that saved intermediate data to a file that can be used to resume the experiment anytime. Other changes include bug fixes where present_results would crash with missing resource data, and a fix that stopped set_resources to always pin cores.