### PR TITLE
Inverse Faults and random MR partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ stress_these_resources: The resources that are good to consider. Current options
 - stress_these_services: The names of the services you would want Throttlebot to stress. To stress all services,simply indicate *. Throttlebot will blacklist any non-application related services by default
 redis_host: The host where the Redis is located (Throttlebot uses Redis as it's data store)
 - stress_policy: The policy that is being used by Throttlebot to decide which containers to consider on each iteration. Note: the only policy implemented right now is 'ALL'
+- gradient_mode: This decides the gradient mode that is being used by Throttlebot. The two options \
+are 'single and 'inverted'.
 
 The "Workload" section describes several Workload specific parameters. Throttlebot will run the experiment in this manner on each iteration.
 
@@ -47,6 +49,21 @@ additional_args: The names of any additional arguments that would be used by thi
   - AMOUNT: The amount provisioned to the MR
   - REPR: This can be either RAW or PERCENT. RAW indicates the exact raw amount of resource being provisioned to the system, while PERCENT indicates the percent of the raw capacity of the machine. 
 There must be an entry for every MR present in the system
+
+3.) The "Filter" section describes Filter specific parameters that Throttlebot will use to prune the \
+search space. There is currently only a single filter_policy.
+- filter_policy: the type of filtering policy that you want. If there is no entry for the filter po\
+licy, then no filtering will be used.
+stress_amount: how much the resources that are being jointly stressed (i.e., the pipelines) are s\
+tressed.
+- filter_exp_trials: the number of trials you want to do for the filter policy
+pipeline_services: the services that should be stressed together. Separate the pipelines by comma\
+s, and the individual services within a pipeline by dashes. For example: "Sparkstreaming-haproxy-\
+mongo,nginx-redis". If you're too lazy to specify particular services to be in a pipeline, there \
+are defaults. The default options are as follows.
+    1.) BY_SERVICE will simply treat each service as a pipeline (i.e., stress all MRs that are part of each service).
+  2) RANDOM: This will create n groups of random partitions of MRs and stress those as MRs. n is set by pipeline_partitions
+- pipeline_partitions: see the pipeline_services option
 
 Once the configuration is set, ensure Redis is up and running, and then start Throttlebot with the following command.
 

--- a/src/README
+++ b/src/README
@@ -11,6 +11,7 @@ stress_these_resources: The resources that are good to consider. Current options
 stress_these_services: The names of the services you would want Throttlebot to stress. To stress all services,simply indicate *. Throttlebot will blacklist any non-application related services by default
 redis_host: The host where the Redis is located (Throttlebot uses Redis as it's data store)
 stress_policy: The policy that is being used by Throttlebot to decide which containers to consider on each iteration.
+gradient_mode: This decides the gradient mode that is being used by Throttlebot. The two options are 'single and 'inverted'. 
 
 The "Workload" section describes several Workload specific parameters. Throttlebot will run the experiment in this manner on each iteration.
 
@@ -21,6 +22,13 @@ additional_args: The names of any additional arguments that would be used by thi
 additional_arg_values: The values of the additional arguments (see additional_args above), listed in the same order as the argument names in additional_args
 tbot_metric: The experiment could return several metrics, but this tells Throttlebot which metric to prioritize MIMRs by. There can only be a single metric here. Ensure that the metric is spelled identically as in your workload.py
 performance_target: A termination point for Throttlebot. This is for Throttlebot to know when to stop running the experiments. This is not yet implemented.
+
+The "Filter" section describes Filter specific parameters that Throttlebot will use to prune the search space. There is currently only a single filter_policy.
+filter_policy: the type of filtering policy that you want. If there is no entry for the filter policy, then no filtering will be used.
+stress_amount: how much the resources that are being jointly stressed (i.e., the pipelines) are stressed.
+filter_exp_trials: the number of trials you want to do for the filter policy
+pipeline_services: the services that should be stressed together. Separate the pipelines by commas, and the individual services within a pipeline by dashes. For example: "Sparkstreaming-haproxy-mongo,nginx-redis". If you're too lazy to specify particular services to be in a pipeline, there are defaults. The default options are as follows. 1.) BY_SERVICE will simply treat each service as a pipeline (i.e., stress all MRs that are part of each service). 2) RANDOM: This will create n groups of random partitions of MRs and stress those as MRs. n is set by pipeline_partitions
+pipeline_partitions: see the pipeline_services option
 
 Once the configuration is set, ensure Redis is up and running, and then start Throttlebot with the following command.
 

--- a/src/mr_gradient.py
+++ b/src/mr_gradient.py
@@ -96,7 +96,7 @@ def schedule_single_gradient(redis_db, mr_candidates, stress_weight):
 def revert_single_gradient(redis_db, mr_candidates, stress_weight):
     mr_to_alloc = {}
     for mr_candidate in mr_candidates:
-        original_mr_alloc = resource_datastore.read_mr_alloc(redis_db, 0)
+        original_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr_candidate)
         mr_to_alloc[mr_candidate] = original_mr_alloc
     return mr_to_alloc
         

--- a/src/mr_gradient.py
+++ b/src/mr_gradient.py
@@ -1,0 +1,124 @@
+'''
+Determines how to set the MR provisions for the gradient step
+Involves parsing the gradient_mode of the sys_config
+
+'''
+
+
+from weighting_converstions import *
+from mr import MR
+import redis_resource as resource_datastore
+
+''' 
+Determines the resources to stress in order to predict the impact
+of increasing a single MR (Otherwise known as the gradient step)
+
+mr_candidates is a zero
+Returns the a list of MRs and their new allocations
+'''
+
+def calculate_mr_gradient_schedule(redis_db, mr_candidates, sys_config, stress_weight):
+    gradient_mode = sys_config['gradient_mode']
+    if gradient_mode == 'single':
+        return schedule_single_gradient(redis_db, mr_candidates, stress_weight)
+    elif gradient_mode == 'inverted':
+        return schedule_inverted_gradient(redis_db, mr_candidates, stress_weight)
+    else:
+        print 'Invalid Gradient Mode. Exiting...'
+        exit()
+
+def revert_mr_gradient_schedule(redis_db, mr_candidates, sys_config):
+    gradient_mode = sys_config['gradient_mode']
+    if gradient_mode == 'single':
+        return revert_single_gradient(redis_db, mr_candidates, stress_weight)
+    elif gradient_mode == 'inverted':
+        return revert_inverted_gradient(redis_db, mr_candidates, stress_weight)
+    else:
+        print 'Invalid gradient mode. Exiting...'
+        exit()
+'''
+Provisions resources for the analytic baseline
+'''
+def prepare_analytic_baseline(redis_db, sys_config, stress_weight):
+    gradient_mode = sys_config['gradient_mode']
+    if gradient_mode == 'single':
+        # Single requires no special preparation of the resources
+        return {}
+    elif gradient_mode == 'inverted':
+        prepare_inverted_baseline(redis_db, stress_weight)
+    else:
+        print 'Invalid Gradient Mode. Exiting...'
+        exit()
+
+'''
+Reverts the resource provisions for the analytic baseline
+(prepare_analytic_baseline does not use this so we do)
+'''
+def revert_analytic_baseline(redis_db, sys_config):
+    gradient_mode = sys_config(['gradient_mode'])
+    if gradient_mode == 'single':
+        return {}
+    elif gradient_mode == 'inverted':
+        revert_inverted_baseline(redis_db)
+    else:
+        print 'Invalid gradient mode. Exiting...'
+        exit()
+        
+# Prepares an all resource stress as the baseline
+def prepare_inverted_baseline(redis_db, stress_weight):
+    mr_to_alloc = {}
+    all_mr_list = resource_datastore.get_all_mrs(redis_db)
+    for mr in all_mr_list:
+        current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
+        new_alloc = convert_percent_to_raw(mr, current_mr_alloc, stress_weight)
+        mr_to_alloc[mr] = new_alloc
+    return all_mr_list
+
+# Reverts the changes in resource preparation
+# Leverages the fact that the original changes were not written to Redis
+def revert_inverted_baseline(redis_db):
+    mr_to_alloc = {}
+    all_mr_list = resource_datastore.read_all_mrs(redis_db)
+    for mr in all_mr_list:
+        current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
+        new_alloc = convert_percent_to_raw(mr, current_mr_alloc, 0)
+        mr_to_alloc[mr] = new_alloc
+    return_all_mr_list
+    
+# Only schedule a single resource
+def schedule_single_gradient(redis_db, mr_candidates, stress_weight):
+    mr_to_alloc = {}
+    for mr_candidate in mr_candidates:
+        current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr_candidate)
+        new_alloc = convert_percent_to_raw(mr_candidate, current_mr_alloc, stress_weight)
+        mr_to_alloc[mr_candidate] = new_alloc
+    return mr_to_alloc
+
+def revert_single_gradient(redis_db, mr_candidates):
+    mr_to_alloc = {}
+    for mr_candidate in mr_candidates:
+        original_mr_alloc = resource_datastore.read_mr_alloc(redis_db, 0)
+        mr_to_alloc[mr_candidate] = original_mr_alloc
+    return mr_to_alloc
+        
+# Stress all resources besides the mr_candidate
+def schedule_inverted_gradient(redis_db, mr_candidates, stress_weight):
+    mr_to_alloc = {}
+    all_mr_list = resource_datastore.get_all_mrs(redis_db)
+    for mr in all_mr_list:
+        if mr in mr_candidates:
+            continue
+        current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
+        new_alloc = convert_percent_to_raw(mr, current_mr_alloc, stress_weight)
+        mr_to_alloc[mr] = new_alloc
+    return mr_to_alloc
+            
+def revert_inverted_gradient(redis_db, mr_candidates):
+    mr_to_alloc = {}
+    all_mr_list = resource_datastore.get_all_mrs(redis_db)
+    for mr in all_mr_list:
+        if mr in mr_candidates:
+            continue
+        original_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
+        mr_to_alloc[mr] = original_alloc
+    return mr_to_alloc

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -135,7 +135,7 @@ def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, a
     redis_db.hset(hash_name, 'action_taken', action_taken_str)
     redis_db.hset(hash_name, 'current_perf', current_perf)
     redis_db.hset(hash_name, 'elapsed_time', elapsed_time)
-    redis_db.hset(hash_name, 'cumulative_mr', cumulative_mr)
+    redis_db.hset(hash_name, 'cumulative_mr', cumm_mr)
     redis_db.hset(hash_name, 'analytic_perf', analytic_perf)
     print 'Summary of Iteration {} written to redis'.format(experiment_iteration_count)
 

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -59,10 +59,6 @@ def write_redis_ranking(redis_db, experiment_iteration_count, perf_metric, mean_
 # Redis sets are ordered from lowest score to the highest score
 # A metric where lower is better would have get_lowest parameter set to True
 def get_top_n_mimr(redis_db, experiment_iteration_count, perf_metric, stress_weight, gradient_mode, optimize_for_lowest=True, num_results_returned=-1):
-    # Revert the optimality constraint for 'Inverted Gradient Mode' -- Ugly Hack.
-    if gradient_mode == 'inverted':
-        optimize_for_lowest = not optimize_for_lowest
-        
     sorted_set_name = generate_ordered_performance_key(experiment_iteration_count, perf_metric, stress_weight)
     print 'Recovering the MIMR from ', sorted_set_name
 
@@ -102,8 +98,6 @@ def get_top_n_filtered_results(redis_db,
                                sys_config,
                                optimize_for_lowest=True,
                                num_results_returned=0):
-    if sys_config['gradient_mode'] == 'inverted': optimize_for_lowest = not optimize_for_lowest
-    
     sorted_set_name = generate_ordered_filter_key(filter_type, exp_iteration)
     print 'INFO: Recovering the bottlenecked pipeline...'
 

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -58,7 +58,11 @@ def write_redis_ranking(redis_db, experiment_iteration_count, perf_metric, mean_
 
 # Redis sets are ordered from lowest score to the highest score
 # A metric where lower is better would have get_lowest parameter set to True
-def get_top_n_mimr(redis_db, experiment_iteration_count, perf_metric, stress_weight, optimize_for_lowest=True, num_results_returned=-1):
+def get_top_n_mimr(redis_db, experiment_iteration_count, perf_metric, stress_weight, gradient_mode, optimize_for_lowest=True, num_results_returned=-1):
+    # Revert the optimality constraint for 'Inverted Gradient Mode' -- Ugly Hack.
+    if gradient_mode == 'inverted':
+        optimize_for_lowest = not optimize_for_lowest
+        
     sorted_set_name = generate_ordered_performance_key(experiment_iteration_count, perf_metric, stress_weight)
     print 'Recovering the MIMR from ', sorted_set_name
 
@@ -119,7 +123,7 @@ Currently assuming that there is only a single metric that a user would care abo
 Elapsed time is in seconds
 '''
 
-def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, action_taken, current_perf, elaps_time, cumulative_mr):
+def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, action_taken, analytic_perf, current_perf, elapsed_time, cumm_mr):
     action_taken_str = ''
     for mr in action_taken:
         action_taken_str += 'MR {} changed by {},'.format(mr.to_string(), action_taken[mr])
@@ -129,8 +133,9 @@ def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, a
     redis_db.hset(hash_name, 'perf_improvement', perf_gain)
     redis_db.hset(hash_name, 'action_taken', action_taken_str)
     redis_db.hset(hash_name, 'current_perf', current_perf)
-    redis_db.hset(hash_name, 'elapsed_time', elaps_time)
+    redis_db.hset(hash_name, 'elapsed_time', elapsed_time)
     redis_db.hset(hash_name, 'cumulative_mr', cumulative_mr)
+    redis_db.hset(hash_name, 'analytic_perf', analytic_perf)
     print 'Summary of Iteration {} written to redis'.format(experiment_iteration_count)
 
 def read_summary_redis(redis_db, experiment_iteration_count):
@@ -139,9 +144,10 @@ def read_summary_redis(redis_db, experiment_iteration_count):
     perf_improvement = redis_db.hget(hash_name, 'perf_improvement')
     action_taken = redis_db.hget(hash_name, 'action_taken')
     current_perf = redis_db.hget(hash_name, 'current_perf')
-    elaps_time = redis_db.hget(hash_name, 'elapsed_time')
+    elapsed_time = redis_db.hget(hash_name, 'elapsed_time')
     cumulative_mr = redis_db.hget(hash_name, 'cumulative_mr')
-    return mimr, action_taken, perf_improvement, current_perf, elaps_time, cumulative_mr
+    analytic_perf = redis_db.hget(hash_name, 'analytic_perf')
+    return mimr, action_taken, perf_improvement,analytic_perf, current_perf, elapsed_time, cumulative_mr
 
 '''
 This index is a mapping of a particular service (which is assumed to be

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -99,17 +99,24 @@ def write_filtered_results(redis_db, filter_type, exp_iteration, repr_string, ex
 def get_top_n_filtered_results(redis_db,
                                filter_type,
                                exp_iteration,
+                               sys_config,
                                optimize_for_lowest=True,
                                num_results_returned=0):
+    if sys_config['gradient_mode'] == 'inverted': optimize_for_lowest = not optimize_for_lowest
+    
     sorted_set_name = generate_ordered_filter_key(filter_type, exp_iteration)
     print 'INFO: Recovering the bottlenecked pipeline...'
 
     # If improving performance means lowering the performance
     # increased performnace should be the MIMR
     if optimize_for_lowest is False:
-        pipeline_score_list = redis_db.zrange(sorted_set_name, 0, num_results_returned, desc=False, withscores=True)
+        pipeline_score_list = redis_db.zrange(sorted_set_name, 0,
+                                              num_results_returned,
+                                              desc=False, withscores=True)
     else:
-        pipeline_score_list = redis_db.zrange(sorted_set_name, 0, num_results_returned, desc=True, withscores=True)
+        pipeline_score_list = redis_db.zrange(sorted_set_name, 0,
+                                              num_results_returned,
+                                              desc=True, withscores=True)
 
     return pipeline_score_list
 

--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -150,10 +150,10 @@ def measure_TODO_response_time(workload_configuration, iterations):
     all_requests['latency_99'] = []
     all_requests['latency_90'] = []
 
-    NUM_REQUESTS = 50000
-    CONCURRENCY = 1000
+    NUM_REQUESTS = 500
+    CONCURRENCY = 50
 
-    post_cmd = 'ab -p post.json -T application/json -n {} -c {} -e results_file http://{}/api/todos > output.txt'.format(NUM_REQUESTS, CONCURRENCY, REST_server_ip)
+    post_cmd = 'ab -p post.json -T application/json -n {} -c {} -s 200 -q -e results_file http://{}/api/todos > output.txt && echo Done'.format(NUM_REQUESTS, CONCURRENCY, REST_server_ip)
 
     clear_cmd = 'python3 clear_entries.py {}'.format(REST_server_ip)
 

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -442,7 +442,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
         current_time_stop = datetime.datetime.now()
         time_delta = current_time_stop - time_start
         cumulative_mr_count += len(mr_to_stress)
-        chart_generator.get_summary_mimr_charts(redis_db, workload_config, baseline_performance, mr_working_set,
+        chart_generator.get_summary_mimr_charts(redis_db, workload_config, current_performance, mr_working_set,
                                                experiment_count, stress_weights, preferred_performance_metric,
                                                time_start)
         
@@ -538,15 +538,13 @@ def run(system_config, workload_config, filter_config, default_mr_config):
         performance_improvement = improved_mean - previous_mean
         
         # Write a summary of the experiment's iterations to Redis
-<<<<<<< 3c4ba6a59f06dfd9b097832ea4d9ff6c61e2b931
         tbot_datastore.write_summary_redis(redis_db, experiment_count, mimr, performance_improvement, action_taken, improved_mean, time_delta.seconds, cumulative_mr_count)
         baseline_performance = improved_performance
-=======
         tbot_datastore.write_summary_redis(redis_db, experiment_count, mimr,
                                            performance_improvement, action_taken,
-                                           analytic_mean, improved_mean) 
+                                           analytic_mean, improved_mean,
+                                           time_delta.seconds, cumulative_mr_count) 
         current_performance = improved_performance
->>>>>>> record and compare against the corre baseline
 
         # Generating overall performance improvement
         chart_generator.get_summary_performance_charts(redis_db, workload_config, experiment_count, time_start)

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -245,6 +245,9 @@ def mean_list(l):
 def remove_outlier(l, n=1):
     n = 1
     no_outlier = [x for x in l if abs(x - np.mean(l)) < np.std(l) * n]
+    #hack 
+    if len(no_outlier) == 0:
+        return l
     return no_outlier
 
 # Update the resource consumption of a machine after an MIMR has been improved
@@ -345,22 +348,21 @@ def run(system_config, workload_config, filter_config, default_mr_config):
     
     # Get the Current Performance -- not used for any analysis, just to benchmark progress!!
     current_performance = measure_baseline(workload_config, baseline_trials)
-    current_performance[preferred_performance_metric] = remove_outlier(baseline_performance[preferred_performance_metric])
+
+    current_performance[preferred_performance_metric] = remove_outlier(current_performance[preferred_performance_metric])
     current_time_stop = datetime.datetime.now()
     time_delta = current_time_stop - time_start
     
     print 'Current (non-analytic) performance measured: {}'.format(current_performance)
 
     tbot_datastore.write_summary_redis(redis_db,
-                                       0,
-                                       MR('initial', 'initial', []),
-                                       0,
-                                       {},
-                                       mean_list(baseline_performance[current_performance_metric]),
-                                       mean_list(baseline_performance[current_performance_metric]),
-                                       time_delta.seconds,
-                                       0)
-
+                                             0,
+                                            MR('initial', 'initial', []),
+                                             0,
+                                             {},
+                                             mean_list(current_performance[preferred_performance_metric]),
+                                             mean_list(current_performance[preferred_performance_metric]),
+                                             time_delta.seconds, 0)
     
     print '============================================'
     print '\n' * 2
@@ -376,15 +378,19 @@ def run(system_config, workload_config, filter_config, default_mr_config):
     while experiment_count < 10:
         # Calculate the analytic baseline that is used to determine MRs
         analytic_provisions = prepare_analytic_baseline(redis_db, sys_config, min(stress_weights))
+        print 'The Analytic provisions are as follows {}'.format(analytic_provisions)
         for mr in analytic_provisions:
             resource_modifier.set_mr_provision(mr, analytic_provisions[mr])
         analytic_baseline = measure_runtime(workload_config, experiment_trials)
-        analytic_baseline[preferred_performance_metric] = remove_outlier(analytic_performance[preferred_performance_metric])
+        analytic_mean = mean_list(analytic_baseline[preferred_performance_metric])
+        print 'The analytic baseline is {}'.format(analytic_baseline)
+        print 'This current performance is {}'.format(current_performance)
+        analytic_baseline[preferred_performance_metric] = remove_outlier(analytic_baseline[preferred_performance_metric])
 
         
         reverted_analytic_provisions = revert_inverted_baseline(redis_db)
         for mr in reverted_analytic_provisions:
-            resource_modifier.set_mr_provision(mr, reverted_provisions[mr])
+            resource_modifier.set_mr_provision(mr, reverted_analytic_provisions[mr])
         
         # Get a list of MRs to stress in the form of a list of MRs
         mr_to_consider = apply_filtering_policy(redis_db,
@@ -421,7 +427,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
                                                    mean_result, mr, stress_weight)
 
                 # Revert the Gradient schedule and provision resources accordingly
-                mr_revert_gradient_schedule = revert_mr_gradient_schedule(redis_db, [mr], stress_weight)
+                mr_revert_gradient_schedule = revert_mr_gradient_schedule(redis_db, [mr], sys_config, stress_weight)
                 for change_mr in mr_revert_gradient_schedule:
                     resource_modifier.set_mr_provision(change_mr, mr_revert_gradient_schedule[change_mr])
                     
@@ -443,7 +449,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
         # Move back into the normal operating basis by removing the baseline prep stresses
         reverted_analytic_provisions = revert_analytic_baseline(redis_db, sys_config)
         for mr in reverted_analytic_provisions:
-            resource_modifier.set_mr_provision(mr, reverted_provisions[mr])
+            resource_modifier.set_mr_provision(mr, reverted_analytic_provisions[mr])
 
         # Recover the results of the experiment from Redis
         max_stress_weight = min(stress_weights)
@@ -615,6 +621,9 @@ def parse_config_file(config_file):
     workload_config['frontend'] = config.get('Workload', 'frontend').split(',')
     workload_config['tbot_metric'] = config.get('Workload', 'tbot_metric')
     workload_config['optimize_for_lowest'] = config.getboolean('Workload', 'optimize_for_lowest')
+    if sys_config['gradient_mode'] == 'inverted':
+        # kind of a hack. If we are doing the inverted stressing for gradient, we actually want to optimize for the most effective.
+        workload_config['optimize_for_lowest'] = not workload_config['optimize_for_lowest']
     workload_config['performance_target'] = config.get('Workload', 'performance_target')
     
     #Additional experiment-specific arguments

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -441,7 +441,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
         # Timing Information for the purpose of experiments
         current_time_stop = datetime.datetime.now()
         time_delta = current_time_stop - time_start
-        cumulative_mr_count += len(mr_to_stress)
+        cumulative_mr_count += len(mr_to_consider)
         chart_generator.get_summary_mimr_charts(redis_db, workload_config, current_performance, mr_working_set,
                                                experiment_count, stress_weights, preferred_performance_metric,
                                                time_start)
@@ -514,7 +514,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
                 mimr = imr
                 break
             else:
-                print 'Improvement Calculated: MR {} failed to improve from {} to {}'.format(mr.to_string(), current_mr_allocation, new_alloc)
+                print 'Improvement Calculated: MR {} failed to improve from {}'.format(mr.to_string(), current_mr_allocation)
                 print 'This IMR cannot be improved. Printing some debugging before exiting...'
 
                 print 'Current MR allocation is {}'.format(current_imr_alloc)
@@ -538,7 +538,6 @@ def run(system_config, workload_config, filter_config, default_mr_config):
         performance_improvement = improved_mean - previous_mean
         
         # Write a summary of the experiment's iterations to Redis
-        tbot_datastore.write_summary_redis(redis_db, experiment_count, mimr, performance_improvement, action_taken, improved_mean, time_delta.seconds, cumulative_mr_count)
         tbot_datastore.write_summary_redis(redis_db, experiment_count, mimr,
                                            performance_improvement, action_taken,
                                            analytic_mean, improved_mean,

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -551,6 +551,7 @@ def parse_config_file(config_file):
     filter_config['filter_policy'] = config.get('Filter', 'filter_policy')
     if filter_config['filter_policy'] == '':
         filter_config['filter_policy'] = None
+    filter_config['pipeline_partitions'] = config.getint('Filter', 'pipeline_partitions')
     filter_config['stress_amount'] = config.getint('Filter', 'stress_amount')
     filter_config['filter_exp_trials'] = config.getint('Filter', 'filter_exp_trials')
     pipeline_string = config.get('Filter', 'pipeline_services')
@@ -612,7 +613,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
         for vm in vm_to_service:
             if len(vm_to_service[vm]) > max_num_services:
                 max_num_services = len(vm_to_service[vm])
-        default_alloc_percentage = 50.0 / max_num_services
+        default_alloc_percentage = 70.0 / max_num_services
 
         mr_list = get_all_mrs_cluster(vm_list, all_services, all_resources)
         for mr in mr_list:

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -293,6 +293,7 @@ def run(system_config, workload_config, filter_config, default_mr_config):
     vm_to_stress = system_config['stress_these_machines']
     machine_type = system_config['machine_type']
     quilt_overhead = system_config['quilt_overhead']
+    gradient_mode = system_config['gradient_mode']
     
     preferred_performance_metric = workload_config['tbot_metric']
     optimize_for_lowest = workload_config['optimize_for_lowest']
@@ -314,16 +315,19 @@ def run(system_config, workload_config, filter_config, default_mr_config):
     
     print '*' * 20
     print 'INFO: RUNNING BASELINE'
-    # Run the baseline experiment
-    baseline_performance = measure_baseline(workload_config, baseline_trials)
-    baseline_performance[preferred_performance_metric] = remove_outlier(baseline_performance[preferred_performance_metric])
-    print 'Baseline performance measured: {}'.format(baseline_performance)
+    
+    # Get the Current Performance -- not used for any analysis, just to benchmark progress!!
+    current_performance = measure_baseline(workload_config, baseline_trials)
+    current_performance[preferred_performance_metric] = remove_outlier(baseline_performance[preferred_performance_metric])
+    print 'Current (non-analytic) performance measured: {}'.format(current_performance)
+
     tbot_datastore.write_summary_redis(redis_db,
                                              0,
                                             MR('initial', 'initial', []),
                                              0,
                                              {},
-                                             mean_list(baseline_performance[preferred_performance_metric]))
+                                             mean_list(baseline_performance[current_performance_metric]),
+                                             mean_list(baseline_performance[current_performance_metric]))
     
     print '============================================'
     print '\n' * 2
@@ -335,24 +339,38 @@ def run(system_config, workload_config, filter_config, default_mr_config):
 
     experiment_count = 1
     while experiment_count < 10:
+        # Calculate the analytic baseline that is used to determine MRs
+        analytic_provisions = prepare_analytic_baseline(redis_db, sys_config, stress_weight)
+        for mr in analytic_provisions:
+            resource_modifier.set_mr_provision(mr, analytic_provisions[mr])
+
+        analytic_baseline = measure_runtime(workload_config, experiment_trials)
+        reverted_provision = revert_inverted_baseline(redis_db)
+        for mr in reverted_analytic_provisions:
+            resource_modifier.set_mr_provision(mr, reverted_provisions[mr])
+        
         # Get a list of MRs to stress in the form of a list of MRs
-        mr_to_stress = apply_filtering_policy(redis_db,
+        mr_to_consider = apply_filtering_policy(redis_db,
                                               mr_working_set,
                                               experiment_count,
                                               system_config,
                                               workload_config,
                                               filter_config)
 
-        for mr in mr_to_stress:
+        for mr in mr_to_consider:
             print '\n' * 2
             print '*' * 20
             print 'Current MR is {}'.format(mr.to_string())
             increment_to_performance = {}
             current_mr_allocation = resource_datastore.read_mr_alloc(redis_db, mr)
             print 'Current MR allocation is {}'.format(current_mr_allocation)
+            
             for stress_weight in stress_weights:
-                new_alloc = convert_percent_to_raw(mr, current_mr_allocation, stress_weight)
-                resource_modifier.set_mr_provision(mr, new_alloc)
+                # Calculate Gradient Schedule and provision resources accordingly
+                mr_gradient_schedule = calculate_mr_gradient_schedule(redis_db, [mr], sys_config, stress_weight)
+                for change_mr in mr_gradient_schedule:
+                    resource_modifier.set_mr_provision(change_mr, mr_gradient_schedule[change_mr])
+                    
                 experiment_results = measure_runtime(workload_config, experiment_trials)
                 
                 #Write results of experiment to Redis
@@ -360,9 +378,11 @@ def run(system_config, workload_config, filter_config, default_mr_config):
                 mean_result = mean_list(preferred_results)
                 tbot_datastore.write_redis_ranking(redis_db, experiment_count, preferred_performance_metric, mean_result, mr, stress_weight)
 
-                # Remove the effect of the resource stressing
-                new_alloc = convert_percent_to_raw(mr, current_mr_allocation, 0)
-                resource_modifier.set_mr_provision(mr, new_alloc)
+                # Revert the Gradient schedule and provision resources accordingly
+                mr_revert_gradient_schedule = revert_mr_gradient_schedule(redis_db, [mr])
+                for change_mr in mr_revert_gradient_schedule:
+                    resource_modiier.set_mr_provision(change_mr, mr_revert_gradient_schedule[change_mr]
+                    
                 increment_to_performance[stress_weight] = experiment_results
 
             # Write the results of the iteration to Redis
@@ -372,8 +392,11 @@ def run(system_config, workload_config, filter_config, default_mr_config):
 
         # Recover the results of the experiment from Redis
         max_stress_weight = min(stress_weights)
-        mimr_list = tbot_datastore.get_top_n_mimr(redis_db, experiment_count, preferred_performance_metric, max_stress_weight, 
-                                                  optimize_for_lowest=optimize_for_lowest, num_results_returned=-1)
+        mimr_list = tbot_datastore.get_top_n_mimr(redis_db, experiment_count,
+                                                  preferred_performance_metric,
+                                                  max_stress_weight, gradient_mode,
+                                                  optimize_for_lowest=optimize_for_lowest,
+                                                  num_results_returned=-1)
 
         imr_list, nimr_list = seperate_mr(mimr_list, mean_list(baseline_performance[preferred_performance_metric]), optimize_for_lowest)
         if len(imr_list) == 0:
@@ -501,6 +524,7 @@ def parse_config_file(config_file):
     sys_config['stress_policy'] = config.get('Basic', 'stress_policy')
     sys_config['machine_type'] = config.get('Basic', 'machine_type')
     sys_config['quilt_overhead'] = config.getint('Basic', 'quilt_overhead')
+    sys_config['gradient_mode'] = config.get('Basic', 'gradient_mode')
 
     # Configuration parameters relating to the filter step
     filter_config['filter_policy'] = config.get('Filter', 'filter_policy')

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -16,6 +16,7 @@ from time import sleep
 
 from collections import namedtuple
 
+from mr_gradient import *
 from stress_analyzer import *
 from weighting_conversions import *
 from remote_execution import *

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -601,6 +601,7 @@ def parse_config_file(config_file):
     filter_config['filter_policy'] = config.get('Filter', 'filter_policy')
     if filter_config['filter_policy'] == '':
         filter_config['filter_policy'] = None
+    filter_config['pipeline_partitions'] = config.getint('Filter', 'pipeline_partitions')
     filter_config['stress_amount'] = config.getint('Filter', 'stress_amount')
     filter_config['filter_exp_trials'] = config.getint('Filter', 'filter_exp_trials')
     pipeline_string = config.get('Filter', 'pipeline_services')
@@ -665,7 +666,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
         for vm in vm_to_service:
             if len(vm_to_service[vm]) > max_num_services:
                 max_num_services = len(vm_to_service[vm])
-        default_alloc_percentage = 50.0 / max_num_services
+        default_alloc_percentage = 70.0 / max_num_services
 
         mr_list = get_all_mrs_cluster(vm_list, all_services, all_resources)
         for mr in mr_list:

--- a/src/test_config.cfg
+++ b/src/test_config.cfg
@@ -10,6 +10,7 @@ redis_host = localhost
 stress_policy = ALL
 machine_type = m4.large
 quilt_overhead = 10
+gradient_mode = stress_all
 
 [Workload]
 

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -59,7 +59,7 @@ def get_performance_over_time_chart(redis_db, experiment_type, experiment_iterat
     x = []
     y = []
     for iteration in range(experiment_iteration_count + 1):
-        _, _, _, curr_perf, elaps_time, _ = tbot_datastore.read_summary_redis(redis_db, iteration)
+        _, _, _,_, curr_perf, elaps_time, _ = tbot_datastore.read_summary_redis(redis_db, iteration)
         x.append(elaps_time)
         y.append(curr_perf)
     plt.plot(x, y, drawstyle='steps-post')
@@ -75,7 +75,7 @@ def get_performance_over_mr_chart(redis_db, experiment_type, experiment_iteratio
     x = []
     y = []
     for iteration in range(experiment_iteration_count + 1):
-        _, _, _, curr_perf, _, cumulative_mr = tbot_datastore.read_summary_redis(redis_db, iteration)
+        _, _, _, _,curr_perf, _, cumulative_mr = tbot_datastore.read_summary_redis(redis_db, iteration)
         x.append(cumulative_mr)
         y.append(curr_perf)
     plt.plot(x, y, drawstyle='steps-post')


### PR DESCRIPTION
Adding a gradient_mode as an input to Throttlebot. Essentially, I am making the stressing pipeline more flexible so we can more easily consider how different combinations of stress can be used to find the MIMR. Now, in addition to a baseline that measures the actual performance, there is something that measures the "analytic performance". The analytic performance can be thought of the baseline performance that is actually used to find the MIMR (as opposed to the actual performance which is just used to understand how effectively Throttlebot performed). 

For the purpose of clarity, a stressing schedule is now calculated inside a new function: mr_gradient.py. 

We now support two types of stressing - single resource stress and the "inverse" stress option. 

Inverse works as follows. We **uniformly** decrease resource allocations by stress_weight amount; this is the new analytic baseline. Then for each MR, we stress all the other MRs by stress_weight amount. We select as MIMR the MR that yields the best performance relative to the uniformly stressed amount. 

Squashed in this PR is also random/flexible pipeline creation. Inside filter_policy, you can now create pipelines that are random partitions of the entire MR working set.

@TsaiAnson Can you quickly review and check to make sure that I didn't mess up anything that you were doing with the timing; I only had time for a quick rebase.