### PR TITLE
Baseline sanity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 *.pyc
 .DS_Store
+.idea/
+results/
+plots/
+test_config.cfg
+tuned_config.csv
+fill_out_resource_debug.txt
+experiment_logs.txt

--- a/src/README
+++ b/src/README
@@ -12,6 +12,7 @@ stress_these_services: The names of the services you would want Throttlebot to s
 redis_host: The host where the Redis is located (Throttlebot uses Redis as it's data store)
 stress_policy: The policy that is being used by Throttlebot to decide which containers to consider on each iteration.
 gradient_mode: This decides the gradient mode that is being used by Throttlebot. The two options are 'single and 'inverted'. 
+rerun_baseline: Boolean that decides if a shortened baseline is rerun at the end of every iteration to ensure pipeline state has not changed
 
 The "Workload" section describes several Workload specific parameters. Throttlebot will run the experiment in this manner on each iteration.
 

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -20,7 +20,8 @@ connected_pattern = re.compile(".+Connected}$")
 ip_pattern = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'
 
 # Container blacklist for container names whose placements should not move
-container_blacklist = ['ovn-controller', 'minion', 'ovs-vswitchd', 'ovsdb-server', 'etcd', 'hantaowang/lumbersexual']
+quilt_blacklist = ['ovn-controller', 'minion', 'ovs-vswitchd', 'ovsdb-server', 'etcd']
+service_blacklist = ['hantaowang/lumbersexual']
 
 # Conversion factor from unit KEY to KiB
 CONVERSION = {"KiB": 1, "MiB": 2**10, "GiB": 2**20}

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -20,7 +20,7 @@ connected_pattern = re.compile(".+Connected}$")
 ip_pattern = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'
 
 # Container blacklist for container names whose placements should not move
-container_blacklist = ['ovn-controller', 'minion', 'ovs-vswitchd', 'ovsdb-server', 'etcd']
+container_blacklist = ['ovn-controller', 'minion', 'ovs-vswitchd', 'ovsdb-server', 'etcd', 'hantaowang/lumbersexual']
 
 # Conversion factor from unit KEY to KiB
 CONVERSION = {"KiB": 1, "MiB": 2**10, "GiB": 2**20}

--- a/src/poll_cluster_state.py
+++ b/src/poll_cluster_state.py
@@ -12,7 +12,7 @@ TODO: Retrieve the information from directly querying the Quilt key-value store
 
 ### Pre-defined blacklist (Temporary)
 quilt_blacklist = ['quilt/ovs', 'google/cadvisor:v0.24.1', 'quay.io/coreos/etcd:v3.0.2', 'mchang6137/quilt:latest',
-                   'throttlebot/quilt:latest']
+                   'throttlebot/quilt:latest', 'hantaowang/lumbersexual']
 
 # Find all the VMs in the current Quilt Cluster
 # Returns a list of IP addresses

--- a/src/poll_cluster_state.py
+++ b/src/poll_cluster_state.py
@@ -12,7 +12,8 @@ TODO: Retrieve the information from directly querying the Quilt key-value store
 
 ### Pre-defined blacklist (Temporary)
 quilt_blacklist = ['quilt/ovs', 'google/cadvisor:v0.24.1', 'quay.io/coreos/etcd:v3.0.2', 'mchang6137/quilt:latest',
-                   'throttlebot/quilt:latest', 'hantaowang/lumbersexual']
+                   'throttlebot/quilt:latest']
+service_blacklist = ['hantaowang/lumbersexual']
 
 # Find all the VMs in the current Quilt Cluster
 # Returns a list of IP addresses
@@ -65,7 +66,7 @@ def parse_quilt_ps_col(column, machine_level=True):
         return result_list[1:]
 
 def get_quilt_services():
-    return quilt_blacklist
+    return quilt_blacklist.extend(service_blacklist)
 
 # Returns all stressable resources available for this
 def get_stressable_resources(cloud_provider='aws-ec2'):
@@ -111,7 +112,7 @@ def get_vm_to_service(vm_ips):
 
         #Assume that the container ids and the service names are ordered in the same way
         for service in service_names:
-            if service in quilt_blacklist:
+            if service in quilt_blacklist or service in service_blacklist:
                 continue
             if vm_ip in vm_to_service:
                 vm_to_service[vm_ip].append(service)

--- a/src/redis_resource.py
+++ b/src/redis_resource.py
@@ -37,13 +37,11 @@ relating to the current resource allocation of a MR
 def generate_mr_key(mr_service, mr_resource):
     return '{},{}'.format(mr_service, mr_resource)
 
-def write_mr_alloc(redis_db, mr, new_allocation):
-    mr_name = 'mr_alloc'
+def write_mr_alloc(redis_db, mr, new_allocation, mr_name = 'mr_alloc'):
     key = generate_mr_key(mr.service_name, mr.resource)
     redis_db.hset(mr_name, key, new_allocation)
 
-def read_mr_alloc(redis_db, mr):
-    mr_name = 'mr_alloc'
+def read_mr_alloc(redis_db, mr, mr_name = 'mr_alloc'):
     key = generate_mr_key(mr.service_name, mr.resource)
     return float(redis_db.hget(mr_name, key))
 

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -723,9 +723,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 baseline_alloc = resource_datastore.read_mr_alloc(redis_db, mr, "baseline_alloc")
                 resource_modifier.set_mr_provision(mr, baseline_alloc, workload_config)
 
-            performance = measure_baseline(workload_config,
-                                                   max(baseline_trials // 2, 1),
-                                                   workload_config['include_warmup'])
+            performance = measure_baseline(workload_config, max(baseline_trials // 2, 1), False)
             performance = remove_outlier(performance[preferred_performance_metric])
 
             acceptable_deviation = 0.1

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -1001,6 +1001,5 @@ if __name__ == "__main__":
         workload_config['instances'] = service_to_deployment['hantaowang/bcd-spark'] + service_to_deployment['hantaowang/bcd-spark-master']
         print workload_config
 
-
     run(sys_config, workload_config, filter_config, mr_allocation, args.last_completed_iter)
 

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -586,6 +586,33 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                                                 experiment_count, stress_weights,
                                                 preferred_performance_metric, time_start)
         
+        
+        # If set, reruns the baseline as a sanity check before the IMR, MIMR is calculated
+        if rerun_baseline:
+            print "\n\nRunning Baseline Again as Sanity Check"
+
+            for mr in mr_working_set:
+                baseline_alloc = resource_datastore.read_mr_alloc(redis_db, mr, "baseline_alloc")
+                resource_modifier.set_mr_provision(mr, baseline_alloc, workload_config)
+
+            performance = measure_baseline(workload_config, max(baseline_trials // 2, 1), False)
+            performance = remove_outlier(performance[preferred_performance_metric])
+
+            acceptable_deviation = 0.1
+
+            if (abs(mean_list(performance) - mean_list(baseline_performance))
+                    / mean_list(baseline_performance)) > acceptable_deviation:
+                print "ERROR: System state has changed since baseline. Deviation greater than {0}%".format(acceptable_deviation * 100)
+                print "Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance))
+                sys.exit("System state has changed since baseline.")
+            else:
+                print "OK"
+
+            for mr in mr_working_set:
+                previous_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
+                resource_modifier.set_mr_provision(mr, previous_alloc, workload_config)
+        
+        
         # Recover the results of the experiment from Redis
         max_stress_weight = min(stress_weights)
         mimr_list = tbot_datastore.get_top_n_mimr(redis_db, experiment_count,
@@ -715,30 +742,6 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         # Checkpoint MR configurations and print
         current_mr_config = resource_datastore.read_all_mr_alloc(redis_db) 
         print_csv_configuration(current_mr_config)
-
-        if rerun_baseline:
-            print "\n\nRunning Baseline Again as Sanity Check"
-
-            for mr in mr_working_set:
-                baseline_alloc = resource_datastore.read_mr_alloc(redis_db, mr, "baseline_alloc")
-                resource_modifier.set_mr_provision(mr, baseline_alloc, workload_config)
-
-            performance = measure_baseline(workload_config, max(baseline_trials // 2, 1), False)
-            performance = remove_outlier(performance[preferred_performance_metric])
-
-            acceptable_deviation = 0.1
-
-            if (abs(mean_list(performance) - mean_list(baseline_performance))
-                    / mean_list(baseline_performance)) > acceptable_deviation:
-                print "ERROR: System state has changed since baseline. Deviation greater than {0}%".format(acceptable_deviation * 100)
-                print "Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance))
-                sys.exit("System state has changed since baseline.")
-            else:
-                print "OK"
-
-            for mr in mr_working_set:
-                previous_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
-                resource_modifier.set_mr_provision(mr, previous_alloc, workload_config)
 
         experiment_count += 1
 

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -10,7 +10,7 @@ import redis_resource as resource_datastore
 from mr import MR
 
 ### Pre-defined blacklist (Temporary)
-blacklist = ['quilt/ovs', 'google/cadvisor:v0.24.1', 'quay.io/coreos/etcd:v3.0.2', 'mchang6137/quilt:latest']
+blacklist = ['quilt/ovs', 'google/cadvisor:v0.24.1', 'quay.io/coreos/etcd:v3.0.2', 'mchang6137/quilt:latest', 'hantaowang/lumbersexual']
 
 # Returns a list of MRs to stress in following iterations
 def generate_mr_from_policy(redis_db, stress_policy):

--- a/src/test_config.cfg
+++ b/src/test_config.cfg
@@ -1,27 +1,31 @@
 [Basic]
 
-baseline_trials = 5
-trials = 5
+baseline_trials = 1
+trials = 1
 stress_weights = -30
 stress_these_resources = CPU-CORE,DISK,NET,MEMORY
 stress_these_services = *
 stress_these_machines = *
 redis_host = localhost
 stress_policy = ALL
-machine_type = m4.2xlarge
+machine_type = m4.large
 quilt_overhead = 10
-gradient_mode = inverted
+gradient_mode = cloud
+rerun_baseline = True
+setting_mode = cloud
+fill_services_first = 
 
 [Workload]
 
-type = bcd
+type = elk
 request_generator = 13.56.79.215
 frontend = 13.56.79.215
-additional_args = container_id
-additional_arg_values = 6f9341945d39
+additional_args = command
+additional_arg_values = load_latency
 tbot_metric = latency
 optimize_for_lowest = True
 performance_target = 10
+include_warmup = False
 
 [Filter]
 


### PR DESCRIPTION
Reruns the baseline after every iteration. If current test of baseline deviates from the original baseline by more than 10% (can be changed), it exits.

Also adds lumber sexual to the blacklists.