### PR TITLE
Allow for asymmetric stress amounts

### DIFF
--- a/src/example_configs/mean_config.cfg
+++ b/src/example_configs/mean_config.cfg
@@ -1,0 +1,34 @@
+[Basic]
+baseline_trials = 10
+trials = 5
+stress_weight = -70
+improve_weight = 70
+stress_these_resources = CPU-QUOTA,DISK,NET,MEMORY
+stress_these_services = *
+stress_these_machines = *
+redis_host = localhost
+stress_policy = ALL
+machine_type = m4.large
+quilt_overhead = 10
+gradient_mode = single
+rerun_baseline = False
+setting_mode = cloud
+fill_services_first =
+
+[Workload]
+type = todo-app
+request_generator = 54.67.92.65
+frontend = 52.53.157.74
+additional_args = command
+additional_arg_values = load_latency
+tbot_metric = latency_99
+optimize_for_lowest = True
+performance_target = 10
+include_warmup = False
+
+[Filter]
+filter_policy = 
+stress_amount = -30
+pipeline_services = 
+filter_exp_trials = 5
+pipeline_partitions = 3

--- a/src/modify_resources.py
+++ b/src/modify_resources.py
@@ -44,7 +44,7 @@ def spark_rewrite_conf(vm_ip, search, replace):
     print "Set all {0} -> {1}: {2}".format(search, replace.split()[1], all(correct))
 
 # Sets the resource provision for all containers in a service
-def set_mr_provision(mr, new_mr_allocation, wc):
+def set_mr_provision(mr, new_mr_allocation, wc=None):
     for vm_ip,container_id in mr.instances:
         ssh_client = get_client(vm_ip)
         print 'STRESSING VM_IP {0} AND CONTAINER {1}, {2} {3}'.format(vm_ip, container_id, mr.resource, new_mr_allocation)
@@ -70,7 +70,7 @@ def reset_mr_provision(mr, wc):
         ssh_client = get_client(vm_ip)
         print 'RESETTING VM_IP {} and container id {}'.format(vm_ip, container_id)
         if mr.resource == 'CPU-CORE':
-            set_cpu_cores(ssh_client, container_id, new_mr_allocation)
+            #set_cpu_cores(ssh_client, container_id, new_mr_allocation)
             reset_cpu_cores(ssh_client, container_id)
         elif mr.resource == 'CPU-QUOTA':
             reset_cpu_quota(ssh_client, container_id)

--- a/src/poll_cluster_state.py
+++ b/src/poll_cluster_state.py
@@ -66,7 +66,7 @@ def parse_quilt_ps_col(column, machine_level=True):
         return result_list[1:]
 
 def get_quilt_services():
-    return quilt_blacklist.extend(service_blacklist)
+    return quilt_blacklist + service_blacklist
 
 # Returns all stressable resources available for this
 def get_stressable_resources(cloud_provider='aws-ec2'):

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -124,7 +124,7 @@ Currently assuming that there is only a single metric that a user would care abo
 Elapsed time is in seconds
 '''
 
-def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, action_taken, analytic_perf, current_perf, elapsed_time, cumm_mr):
+def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, action_taken, analytic_perf, current_perf, elapsed_time, cumm_mr, is_backtrack=False):
     action_taken_str = ''
     for mr in action_taken:
         action_taken_str += 'MR {} changed by {},'.format(mr.to_string(), action_taken[mr])
@@ -137,6 +137,7 @@ def write_summary_redis(redis_db, experiment_iteration_count, mimr, perf_gain, a
     redis_db.hset(hash_name, 'elapsed_time', elapsed_time)
     redis_db.hset(hash_name, 'cumulative_mr', cumm_mr)
     redis_db.hset(hash_name, 'analytic_perf', analytic_perf)
+    redis_db.hset(hash_name, 'is_backtrack', is_backtrack)
     print 'Summary of Iteration {} written to redis'.format(experiment_iteration_count)
 
 def read_summary_redis(redis_db, experiment_iteration_count):
@@ -148,7 +149,8 @@ def read_summary_redis(redis_db, experiment_iteration_count):
     elapsed_time = redis_db.hget(hash_name, 'elapsed_time')
     cumulative_mr = redis_db.hget(hash_name, 'cumulative_mr')
     analytic_perf = redis_db.hget(hash_name, 'analytic_perf')
-    return mimr, action_taken, perf_improvement,analytic_perf, current_perf, elapsed_time, cumulative_mr
+    is_backtrack = redis_db.hget(hash_name, 'is_backtrack')
+    return mimr, action_taken, perf_improvement,analytic_perf, current_perf, elapsed_time, cumulative_mr, is_backtrack
 
 
 '''

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -788,7 +788,7 @@ def backtrack_overstep(redis_db, workload_config, experiment_count,
     
     for mr in action_taken:
         # Skip if action taken was to steal from a NIMR
-        if action_taken[mr] < 0:
+        if action_taken[mr] <= 0:
             continue
         
         new_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -10,8 +10,8 @@ import redis_client as tbot_datastore
 '''
 Get charts of the results of the experiments
 '''
-def get_summary_mimr_charts(redis_db, workload_config, baseline_perf, mr_to_stress, experiment_iteration_count, stress_weights, preferred_performance_metric, time_id):
-    max_stress = min(stress_weights)
+def get_summary_mimr_charts(redis_db, workload_config, baseline_perf, mr_to_stress, experiment_iteration_count, stress_weight, preferred_performance_metric, time_id):
+    max_stress = stress_weight
     width = 0.8
     indices = np.arange(experiment_iteration_count + 1)
     chart_directory = 'results/graphs/{}/'.format(workload_config['type'] + str(time_id))

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -59,7 +59,7 @@ def get_performance_over_time_chart(redis_db, experiment_type, experiment_iterat
     x = []
     y = []
     for iteration in range(experiment_iteration_count + 1):
-        _, _, _,_, curr_perf, elaps_time, _ = tbot_datastore.read_summary_redis(redis_db, iteration)
+        _, _, _,_, curr_perf, elaps_time, _, _ = tbot_datastore.read_summary_redis(redis_db, iteration)
         x.append(elaps_time)
         y.append(curr_perf)
     plt.plot(x, y, drawstyle='steps-post')
@@ -75,7 +75,7 @@ def get_performance_over_mr_chart(redis_db, experiment_type, experiment_iteratio
     x = []
     y = []
     for iteration in range(experiment_iteration_count + 1):
-        _, _, _, _,curr_perf, _, cumulative_mr = tbot_datastore.read_summary_redis(redis_db, iteration)
+        _, _, _, _,curr_perf, _, cumulative_mr,_ = tbot_datastore.read_summary_redis(redis_db, iteration)
         x.append(cumulative_mr)
         y.append(curr_perf)
     plt.plot(x, y, drawstyle='steps-post')


### PR DESCRIPTION
- Allow for asymmetric stress amounts, disallow user from specifying more than a single stress value to test. Requires modification to the submitted config file (see example_configs/mean_config.cfg for an example)

- Allow for simple backtracking mechanism -- if we provision more to a resource and it results in an increase or performance plateau, test the median allocation between the new allocation and the previous allocation; if the median allocation results in an equal or better performance, revert to the median allocation.

Quick review: @hantaowang

FYI @TsaiAnson 