### PR TITLE
Handle NIMR stealing more efficiently + signal handling

### DIFF
--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -865,11 +865,6 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
 
     print 'Convergence achieved - start squeezing NIMRs'
 
-    current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
-    print 'meowmoew'
-    for mr in current_mr_config:
-        print '{} = {}'.format(mr.to_string(), current_mr_config[mr])
-        
     successful_steal = recent_nimr_list
     # Tentatively do this only 5 times to save time
     for x in range(5):


### PR DESCRIPTION
- Slight optimization to NIMR stealing -- don't steal from NIMRs that do not actually make a difference.
- At conclusion of run, squeeze NIMRs continually to further compress them.
- Signal handling for Throttlebot, fail gracefully.