### PR TITLE
Removed spaces for memory utilization

### DIFF
--- a/src/get_utilization.py
+++ b/src/get_utilization.py
@@ -7,8 +7,13 @@ from remote_execution import *
 # Gets the current memory utilization in bytes
 def get_current_memory_utilization(ssh_client, container_id):
     get_memory_cmd = 'cat /sys/fs/cgroup/memory/docker/{}*/memory.usage_in_bytes'.format(container_id)
-    _,memory_utilization,_ = ssh_exec(ssh_client, get_memory_cmd, modifies_container=True, return_error=True)
+    _,memory_utilization_obj,stderr = ssh_exec(ssh_client, get_memory_cmd, modifies_container=True, return_error=True)
+
+    memory_utilization_string = memory_utilization_obj.read()
+    memory_utilization_float = float("".join(memory_utilization_string.split()))
+
     print "Recovering the memory utilization"
-    return float(memory_utilization.read())
-    
+    print memory_utilization_float
+
+    return memory_utilization_float
     

--- a/src/get_utilization.py
+++ b/src/get_utilization.py
@@ -13,7 +13,5 @@ def get_current_memory_utilization(ssh_client, container_id):
     memory_utilization_float = float("".join(memory_utilization_string.split()))
 
     print "Recovering the memory utilization"
-    print memory_utilization_float
 
     return memory_utilization_float
-    


### PR DESCRIPTION
Sometimes, memory_utilization_obj.read() returns a string that contains a whitespace. In this case, float() will fail to run and raise an error. I've fixed this problem by removing the whitespaces from memory_utilization_string before converting it into a float.