### PR TITLE
Changed print statements to log statements, added --log flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ are defaults. The default options are as follows.
 
 Once the configuration is set, ensure Redis is up and running, and then start Throttlebot with the following command.
 
-$ python run_throttlebot.py <config_file_name>
+$ python run_throttlebot.py --config_file <config_file_name>
+
+Optionally, you can add the --log flag to log to a specific file. Without a --log flag, Throttlebot will print to stdout.
+
+$ python run_throttlebot.py --config_file <config_file_name> --log <log_file_name>
 
 2. If necessary, set the "password" variables for your SSH keys. Without this, Throttlebot cannot execute commands on the virtual machines. They are located within remote_execution.py and measure_performance_MEAN_py3.py.

--- a/src/automate_clampdown.py
+++ b/src/automate_clampdown.py
@@ -5,6 +5,8 @@ Automate Many experiments of Throttlebot
 import argparse
 import traceback
 
+import logging
+
 from run_clampdown import *
 
 if __name__ == "__main__":
@@ -29,12 +31,12 @@ if __name__ == "__main__":
             experiment_end = time.time()
             runtime = experiment_end - experiment_start
             trial_to_overhead[count] = (experiment_iteration, runtime)
-            print 'Trial overhead is {}'.format(trial_to_overhead)
+            logging.info('Trial overhead is {}'.format(trial_to_overhead))
         except Exception, err:
             traceback.print_exc()
 
-    print 'Completed!'
-    print trial_to_overhead
+    logging.info('Completed!')
+    logging.info(trial_to_overhead)
 
 # (5,436 sec)
 # {0: (6, 486.6667308807373), 1: (4, 345.2677080631256), 2: (5, 493.66548919677734), 3: (13, 1544.4055361747742), 4: (4, 332.8213529586792), 5: (7, 621.3301801681519)}

--- a/src/automate_exp.py
+++ b/src/automate_exp.py
@@ -5,6 +5,8 @@ Automate Many experiments of Throttlebot
 import argparse
 import traceback
 
+import logging
+
 from run_throttlebot import *
 
 if __name__ == "__main__":
@@ -12,7 +14,12 @@ if __name__ == "__main__":
     parser.add_argument("--num_runs", help="Number of times to run the experiment")
     parser.add_argument("--config_file1", help="Configuration File for Throttlebot Execution")
     parser.add_argument("--resource_config", help='Default Resource Allocation for Throttlebot')
+    parser.add_argument("--log", help='Default Logging File')
     args = parser.parse_args()
+
+    # Setup Logging
+    logging.basicConfig(filename=args.log, level=logging.INFO)
+    logging.info('Started Logging')
 
     conf_files = ['MIMR1.cfg', 'MIMR1INV.cfg', 'MIMR2.cfg']
     for conf_file in conf_files:
@@ -29,4 +36,4 @@ if __name__ == "__main__":
             except Exception, err:
                 traceback.print_exc()
 
-    print 'Completed!'
+    logging.info('Completed!')

--- a/src/consolidate_services.py
+++ b/src/consolidate_services.py
@@ -6,6 +6,8 @@ from instance_specs import *
 from poll_cluster_state import *
 from copy import deepcopy
 
+import logging
+
 # Bin pack resources
 def parse_config_csv(resource_config_csv):
     mr_allocation = {}
@@ -225,7 +227,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
                     machine_to_service[machine_index].append(service_name)
                     containers_seen += 1
                 else:
-                    print 'Error: You have selected too many IMRs for consideration!'
+                    logging.error('Error: You have selected too many IMRs for consideration!')
                     return {}
 
         # Don't double count the services
@@ -253,7 +255,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
             if fit_found:
                 machine_to_service[machine_index].append(service_name)
             else:
-                print 'No valid placement found. Returning'
+                logging.error('No valid placement found. Returning')
                 return {}
 
         return machine_to_service
@@ -292,7 +294,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
                 machine_to_service[machine_index].append(service_name)
 
                 if fit_found is False:
-                    print 'Fit not found. You have a bug. Exiting..'
+                    logging.error('Fit not found. You have a bug. Exiting..')
                     exit()
 
         return machine_to_service
@@ -308,7 +310,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
                                 key=lambda x: mr_allocation[service_to_mr[x][resource_index[imr_resource]]])
 
     first_fit_placements = ff(service_containers)
-    print 'First fit service placement is {}'.format(first_fit_placements)
+    logging.info('First fit service placement is {}'.format(first_fit_placements))
 
     # First place the services that show up as MIMRs
     optimal_num_machines = len(first_fit_placements.keys())
@@ -320,7 +322,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
         if len(imr_aware_service_placement.keys()) != 0:
             break
 
-    print 'IMR Aware Service Placement is {}'.format(imr_aware_service_placement)
+    logging.info('IMR Aware Service Placement is {}'.format(imr_aware_service_placement))
     return first_fit_placements, imr_aware_service_placement
 
 if __name__ == "__main__":

--- a/src/consolidate_services.py
+++ b/src/consolidate_services.py
@@ -227,7 +227,7 @@ def ffd_pack(mr_allocation, instance_type, sort_by='CPU-QUOTA', imr_list=[]):
                     machine_to_service[machine_index].append(service_name)
                     containers_seen += 1
                 else:
-                    logging.error('Error: You have selected too many IMRs for consideration!')
+                    logging.error('You have selected too many IMRs for consideration!')
                     return {}
 
         # Don't double count the services

--- a/src/filter_policy.py
+++ b/src/filter_policy.py
@@ -78,7 +78,7 @@ def apply_pipeline_filter(redis_db,
                           filter_config):
 
     logging.info('*' * 20)
-    logging.info('INFO: Applying Filtering Pipeline')
+    logging.info('Applying Filtering Pipeline')
 
     logging.info('Filter config is {}'.format(filter_config))
     logging.info('MR working set is {}'.format(mr_working_set))

--- a/src/filter_policy.py
+++ b/src/filter_policy.py
@@ -13,6 +13,8 @@ from weighting_conversions import *
 from run_throttlebot import *
 from mr import MR
 
+import logging
+
 FILTER_LOGS = 'filter_logs.txt'
 
 '''
@@ -54,7 +56,7 @@ def apply_filtering_policy(redis_db,
             pipeline_mr = pipeline_groups[int(pipeline_repr)]
             current_performance_mean = mean_list(current_performance[metric])
             is_constant_perf = is_performance_constant(current_performance_mean, pipeline_perf, error_tolerance)
-            print 'For pipeline {}, the current mean is {} and new performance is {}'.format([mr.to_string() for mr in pipeline_mr], current_performance_mean, pipeline_perf)
+            logging.info('For pipeline {}, the current mean is {} and new performance is {}'.format([mr.to_string() for mr in pipeline_mr], current_performance_mean, pipeline_perf))
             if is_constant_perf:
                 mr_of_interest.append(pipeline_mr)
 
@@ -75,11 +77,11 @@ def apply_pipeline_filter(redis_db,
                           workload_config,
                           filter_config):
 
-    print '*' * 20
-    print 'INFO: Applying Filtering Pipeline'
+    logging.info('*' * 20)
+    logging.info('INFO: Applying Filtering Pipeline')
 
-    print 'Filter config is {}'.format(filter_config)
-    print 'MR working set is {}'.format(mr_working_set)
+    logging.info('Filter config is {}'.format(filter_config))
+    logging.info('MR working set is {}'.format(mr_working_set))
     
     machine_type = system_config['machine_type']
 
@@ -90,7 +92,7 @@ def apply_pipeline_filter(redis_db,
 
     pipeline_groups = []
 
-    print 'Pipelined services are {}'.format(pipelined_services)
+    logging.info('Pipelined services are {}'.format(pipelined_services))
     # No specified pipelined services indicates that each pipeline is a service
     if pipelined_services[0][0] == 'BY_SERVICE':
         service_names = list(set([mr.service_name for mr in mr_working_set]))
@@ -100,10 +102,10 @@ def apply_pipeline_filter(redis_db,
     elif pipelined_services[0][0] == 'RANDOM':
         pipeline_groups = gen_mr_random_split(mr_working_set, pipeline_partitions)
 
-    print "The pipeline groups are being printed below: "
+    logging.info("The pipeline groups are being printed below: ")
     for pipeline_group in pipeline_groups:
         pipeline_group = [mr.to_string() for mr in pipeline_group]
-        print 'A pipeline is {}'.format(pipeline_group)
+        logging.info('A pipeline is {}'.format(pipeline_group))
         
     tbot_metric = workload_config['tbot_metric']
     optimize_for_lowest = workload_config['optimize_for_lowest']

--- a/src/generate_ids.py
+++ b/src/generate_ids.py
@@ -3,12 +3,14 @@ from remote_execution import *
 from run_spark_streaming import *
 import argparse
 
+import logging
+
 def print_ip_to_container_id(services_to_stress, dictionary_ip_cont):
-    print dictionary_ip_cont
+    logging.info(dictionary_ip_cont)
     for service in services_to_stress:
         results = dictionary_ip_cont[service]
         for container in results:
-            print '{},{},'.format(container[0], container[1])
+            logging.info('{},{},'.format(container[0], container[1]))
 
 def start_experiments(dictionary_ip_cont):
     sending_time = 200
@@ -20,9 +22,9 @@ def start_experiments(dictionary_ip_cont):
         ip,container_id = container
         client = get_client(ip)
         run_cmd(start_exp_cmd, client, container_id, False, True)
-    print 'All experiments started'
+    logging.info('All experiments started')
     time.sleep(sending_time)
-    print 'All experiments completed -- collect results on any machine'
+    logging.info('All experiments completed -- collect results on any machine')
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/get_utilization.py
+++ b/src/get_utilization.py
@@ -7,8 +7,13 @@ from remote_execution import *
 # Gets the current memory utilization in bytes
 def get_current_memory_utilization(ssh_client, container_id):
     get_memory_cmd = 'cat /sys/fs/cgroup/memory/docker/{}*/memory.usage_in_bytes'.format(container_id)
-    _,memory_utilization,_ = ssh_exec(ssh_client, get_memory_cmd, modifies_container=True, return_error=True)
+    _,memory_utilization_obj,stderr = ssh_exec(ssh_client, get_memory_cmd, modifies_container=True, return_error=True)
+
+    memory_utilization_string = memory_utilization_obj.read()
+    memory_utilization_float = float("".join(memory_utilization_string.split()))
+
     print "Recovering the memory utilization"
-    return float(memory_utilization.read())
-    
+    print memory_utilization_float
+
+    return memory_utilization_float
     

--- a/src/get_utilization.py
+++ b/src/get_utilization.py
@@ -13,7 +13,5 @@ def get_current_memory_utilization(ssh_client, container_id):
     memory_utilization_float = float("".join(memory_utilization_string.split()))
 
     print "Recovering the memory utilization"
-    print memory_utilization_float
 
     return memory_utilization_float
-    

--- a/src/get_utilization.py
+++ b/src/get_utilization.py
@@ -4,6 +4,8 @@ from container_information import *
 from subprocess import Popen, PIPE
 from remote_execution import *
 
+import logging
+
 # Gets the current memory utilization in bytes
 def get_current_memory_utilization(ssh_client, container_id):
     get_memory_cmd = 'cat /sys/fs/cgroup/memory/docker/{}*/memory.usage_in_bytes'.format(container_id)
@@ -12,6 +14,6 @@ def get_current_memory_utilization(ssh_client, container_id):
     memory_utilization_string = memory_utilization_obj.read()
     memory_utilization_float = float("".join(memory_utilization_string.split()))
 
-    print "Recovering the memory utilization"
+    logging.info("Recovering the memory utilization")
 
     return memory_utilization_float

--- a/src/measure_performance_MEAN_py3.py
+++ b/src/measure_performance_MEAN_py3.py
@@ -49,7 +49,7 @@ def ssh_exec(ssh_client, cmd):
     _, _, stderr = ssh_client.exec_command(cmd)
     err = stderr.read()
     if err:
-        logging.info("Error execing {}: {}".format(cmd, err))
+        logging.error("Error execing {}: {}".format(cmd, err))
 
 def get_client(ip):
     client = paramiko.SSHClient()

--- a/src/measure_performance_MEAN_py3.py
+++ b/src/measure_performance_MEAN_py3.py
@@ -13,6 +13,8 @@ import paramiko
 import csv
 from multiprocessing.dummy import Pool as ThreadPool
 
+import logging
+
 REST_URL = '/api/todos'
 
 REMOTE_POST_SCRIPT = "remote_make_post.py"
@@ -47,7 +49,7 @@ def ssh_exec(ssh_client, cmd):
     _, _, stderr = ssh_client.exec_command(cmd)
     err = stderr.read()
     if err:
-        print ("Error execing {}: {}".format(cmd, err))
+        logging.info("Error execing {}: {}".format(cmd, err))
 
 def get_client(ip):
     client = paramiko.SSHClient()

--- a/src/mr_gradient.py
+++ b/src/mr_gradient.py
@@ -8,6 +8,8 @@ from weighting_conversions import *
 from mr import MR
 import redis_resource as resource_datastore
 
+import logging
+
 ''' 
 Determines the resources to stress in order to predict the impact
 of increasing a single MR (Otherwise known as the gradient step)
@@ -23,7 +25,7 @@ def calculate_mr_gradient_schedule(redis_db, mr_candidates, sys_config, stress_w
     elif gradient_mode == 'inverted':
         return schedule_inverted_gradient(redis_db, mr_candidates, stress_weight)
     else:
-        print 'Invalid Gradient Mode. Exiting...'
+        logging.error('Invalid Gradient Mode. Exiting...')
         exit()
 
 def revert_mr_gradient_schedule(redis_db, mr_candidates, sys_config, stress_weight):
@@ -33,7 +35,7 @@ def revert_mr_gradient_schedule(redis_db, mr_candidates, sys_config, stress_weig
     elif gradient_mode == 'inverted':
         return revert_inverted_gradient(redis_db, mr_candidates, stress_weight)
     else:
-        print 'Invalid gradient mode. Exiting...'
+        logging.error('Invalid gradient mode. Exiting...')
         exit()
 '''
 Provisions resources for the analytic baseline
@@ -46,7 +48,7 @@ def prepare_analytic_baseline(redis_db, sys_config, stress_weight):
     elif gradient_mode == 'inverted':
         return prepare_inverted_baseline(redis_db, stress_weight)
     else:
-        print 'Invalid Gradient Mode. Exiting...'
+        logging.error('Invalid Gradient Mode. Exiting...')
         exit()
 
 '''
@@ -60,7 +62,7 @@ def revert_analytic_baseline(redis_db, sys_config):
     elif gradient_mode == 'inverted':
         return revert_inverted_baseline(redis_db)
     else:
-        print 'Invalid gradient mode. Exiting...'
+        logging.error('Invalid gradient mode. Exiting...')
         exit()
         
 # Prepares an all resource stress as the baseline

--- a/src/remote_execution.py
+++ b/src/remote_execution.py
@@ -1,4 +1,5 @@
 import paramiko
+import logging
 
 def get_client(ip):
     client = paramiko.SSHClient()
@@ -10,7 +11,7 @@ def ssh_exec(ssh_client, cmd, modifies_container=False, return_error=False):
     _,stdout,stderr = ssh_client.exec_command(cmd)
     err = stderr.read()
     if err:
-        print ("Error execing {}: {}".format(cmd, err))
+        logging.info("Error execing {}: {}".format(cmd, err))
 
         if modifies_container:
             raise SystemError('Error caused by container ID')

--- a/src/research_functions.py
+++ b/src/research_functions.py
@@ -13,18 +13,20 @@ from poll_cluster_state import *
 from stress_analyzer import *
 from run_throttlebot import parse_resource_config_file
 
+import logging
+
 def reset_resources():
     vm_list = get_actual_vms()
     all_services = get_actual_services()
     all_resources = get_stressable_resources()
 
     mr_list = get_all_mrs_cluster(vm_list, all_services, all_resources)
-    print 'Resetting provisions for {}'.format([mr.to_string() for mr in mr_list])
+    logging.info('Resetting provisions for {}'.format([mr.to_string() for mr in mr_list]))
 
     for mr in mr_list:
         resource_modifier.reset_mr_provision(mr)
 
-    print 'All MRs reset'
+    logging.info('All MRs reset')
 
 # # INCOMPLETE
 # # Must set preferred performance index
@@ -86,5 +88,5 @@ if __name__ == "__main__":
     if args.reset_resources:
         reset_resources()
     elif args.plot_cumm_mr != 0:
-        print 'Plotting up to {} iterations'.format(args.plot_cumm_mr)
+        logging.info('Plotting up to {} iterations'.format(args.plot_cumm_mr))
         # plot_cumm_mr(redis_db, args.plot_cumm_mr, workload_config, filter_config)

--- a/src/run_clampdown.py
+++ b/src/run_clampdown.py
@@ -38,6 +38,7 @@ import redis_resource as resource_datastore
 import modify_resources as resource_modifier
 import visualizer as chart_generator
 
+import logging
 
 '''
 class GracefulKiller:
@@ -49,10 +50,10 @@ class GracefulKiller:
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     def exit_gracefully(self, signum, frame):
-        print 'NIMRs have now also been squeezed, printing final values.'
+        logging.info('NIMRs have now also been squeezed, printing final values.')
         current_mr_config = resource_datastore.read_all_mr_alloc(self.redis_db)
         for mr in current_mr_config:
-            print '{} = {}'.format(mr.to_string(), current_mr_config[mr])
+            logging.info('{} = {}'.format(mr.to_string(), current_mr_config[mr]))
 
         print_csv_configuration(current_mr_config)
         exit()
@@ -71,12 +72,12 @@ def init_service_placement_r(redis_db, default_mr_configuration):
 # Set the current resource configurations withi the actual containers
 # Data points in resource_config are expressed in percentage change
 def init_resource_config(redis_db, default_mr_config, machine_type, wc):
-    print 'Initializing the Resource Configurations in the containers'
+    logging.info('Initializing the Resource Configurations in the containers')
     instance_specs = get_instance_specs(machine_type)
     for mr in default_mr_config:
         new_resource_provision = int(default_mr_config[mr])
         if check_change_mr_viability(redis_db, mr, new_resource_provision)[0] is False:
-            print 'Initial Resource provisioning for {} is too much. Exiting...'.format(mr.to_string())
+            logging.error('Initial Resource provisioning for {} is too much. Exiting...'.format(mr.to_string()))
             exit()
 
         # Enact the change in resource provisioning
@@ -89,7 +90,7 @@ def init_resource_config(redis_db, default_mr_config, machine_type, wc):
 
 # Initializes the maximum capacity and current consumption of Quilt
 def init_cluster_capacities_r(redis_db, machine_type, quilt_overhead):
-    print 'Initializing the per machine capacities'
+    logging.info('Initializing the per machine capacities')
     resource_alloc = get_instance_specs(machine_type)
     min_alloc = get_instance_min_specs()
 
@@ -147,8 +148,8 @@ def seperate_mr(mr_list, baseline_performance, optimize_for_lowest, within_x=0.0
     for mr_result in mr_list:
         mr,exp_performance = mr_result
         perf_diff = exp_performance - baseline_performance
-        print 'perf diff is {}'.format(perf_diff)
-        print 'leeway is {}'.format(within_x * baseline_performance)
+        logging.info('perf diff is {}'.format(perf_diff))
+        logging.info('leeway is {}'.format(within_x * baseline_performance))
 
         if is_performance_constant(baseline_performance, exp_performance, within_x):
             nimr_list.append(mr)
@@ -227,7 +228,7 @@ def check_decrease_mr_viability(redis_db, mr, proposed_change):
             valid_change = -1 * (current_alloc - min_dict[resource])
             return False, valid_change
     except KeyError:
-        print 'Invalid Resource'
+        logging.error('Invalid Resource')
         exit()
 
 # Allow the MR to fill out the remainder of the resources on the machine
@@ -252,8 +253,8 @@ def fill_out_resource(redis_db, imr):
             myfile.write(debug_statement)
 
     if improvement_proposal < 0:
-        print 'WARNING: Improvement proposal is less than 0 (it is {})'.format(improvement_proposal)
-        print 'Check out fill_out_resource_debug.txt to help diagnose the problem'
+        logging.warning('Improvement proposal is less than 0 (it is {})'.format(improvement_proposal))
+        logging.warning('Check out fill_out_resource_debug.txt to help diagnose the problem')
 
         # get immediate results just by setting the proposal to zero in this case
         improvement_proposal = 0
@@ -267,13 +268,13 @@ def fill_out_resource(redis_db, imr):
 # In the NIMR list for NIMRs to be de-allocated.
 # Returns a list of NIMRs to reduce and the raw amount to reduce each NIMR, and the amount to incease the IMR bu
 def create_decrease_nimr_schedule(redis_db, imr, nimr_list, stress_weight, target_imr_increase):
-    print 'IMR is {}'.format(imr.to_string())
+    logging.info('IMR is {}'.format(imr.to_string()))
 
     pruned_nimr_list = []
     # Filter out NIMRs that are not the same resource type as mr
     for nimr in list(nimr_list):
-        print 'NIMR resource: {} '.format(nimr.resource)
-        print 'IMR resource: {}'.format(imr.resource)
+        logging.info('NIMR resource: {} '.format(nimr.resource))
+        logging.info('IMR resource: {}'.format(imr.resource))
         if nimr.resource == imr.resource: pruned_nimr_list.append(nimr)
 
     if len(pruned_nimr_list) == 0:
@@ -349,7 +350,7 @@ def create_decrease_nimr_schedule(redis_db, imr, nimr_list, stress_weight, targe
     machine_to_imr = containers_per_vm(imr)
     max_imr_containers = max([machine_to_imr[machine_ip] for machine_ip in machine_to_imr])
     proposed_imr_improvement = abs(min_vm_removal) / max_imr_containers
-    print 'proposed imr improvement is {}'.format(proposed_imr_improvement)
+    logging.info('proposed imr improvement is {}'.format(proposed_imr_improvement))
     assert proposed_imr_improvement >= 0
     if proposed_imr_improvement == 0:
         return {}, 0
@@ -372,7 +373,7 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
         new_alloc = convert_percent_to_raw(nimr, nimr_alloc, stress_weight)
 
         valid_change, valid_change_amount = check_change_mr_viability(redis_db, nimr, new_alloc - nimr_alloc)
-        print 'For NIMR {}, the valid change amount is {}'.format(nimr.to_string(), valid_change_amount)
+        logging.info('For NIMR {}, the valid change amount is {}'.format(nimr.to_string(), valid_change_amount))
         assert valid_change_amount <= 0
 
         if valid_change_amount == 0:
@@ -383,7 +384,7 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
                 continue
 
             vm_to_removal[vm_ip] += valid_change_amount * reduction_multiplier[vm_ip]
-            print 'For vm {}, we are adding {}'.format(vm_ip, valid_change_amount * reduction_multiplier[vm_ip])
+            logging.info('For vm {}, we are adding {}'.format(vm_ip, valid_change_amount * reduction_multiplier[vm_ip]))
 
         nimr_reduction[nimr] = valid_change_amount
         min_vm_removal = min([abs(vm_to_removal[vm_ip]) for vm_ip in vm_to_removal])
@@ -397,12 +398,12 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
 def simulate_mr_provisions(redis_db, imr, imr_proposal, nimr_diff_proposal):
     for nimr in nimr_diff_proposal:
         new_nimr_alloc = resource_datastore.read_mr_alloc(redis_db, nimr) + nimr_diff_proposal[nimr]
-        print 'Changing NIMR {} from {} to {}'.format(nimr.to_string(), resource_datastore.read_mr_alloc(redis_db, nimr), new_nimr_alloc)
+        logging.info('Changing NIMR {} from {} to {}'.format(nimr.to_string(), resource_datastore.read_mr_alloc(redis_db, nimr), new_nimr_alloc))
         resource_modifier.set_mr_provision(nimr, int(new_nimr_alloc))
 
     old_imr_alloc = resource_datastore.read_mr_alloc(redis_db, imr)
     new_imr_alloc = old_imr_alloc + imr_proposal
-    print 'changing imr from {} to {}'.format(old_imr_alloc, new_imr_alloc)
+    logging.info('changing imr from {} to {}'.format(old_imr_alloc, new_imr_alloc))
     resource_modifier.set_mr_provision(imr, int(new_imr_alloc))
 
 # Revert to nimr allocation to most recently committed values, reverts "simulation"
@@ -457,7 +458,7 @@ def update_mr_config(redis_db, mr_in_play):
 
 # Prints all improvements attempted by Throttlebot
 def print_all_steps(redis_db, total_experiments, sys_config, workload_config, filter_config):
-    print 'Steps towards improving performance'
+    logging.info('Steps towards improving performance')
     net_improvement = 0
 
     with open("experiment_logs.txt", "a") as myfile:
@@ -470,7 +471,7 @@ def print_all_steps(redis_db, total_experiments, sys_config, workload_config, fi
         if is_backtrack == 'True':
             is_backtrack_string = 'backtrack'
 
-        print 'Iteration {}_{}, Mimr = {}, New allocation = {}, Performance Improvement = {}, Analytic Performance = {}, Performance after improvement = {}, Elapsed Time = {}, Cummulative MR = {}'.format(experiment_count, is_backtrack_string, mimr, action_taken, perf_improvement, analytic_perf, current_perf, elapsed_time, cumm_mr)
+        logging.info('Iteration {}_{}, Mimr = {}, New allocation = {}, Performance Improvement = {}, Analytic Performance = {}, Performance after improvement = {}, Elapsed Time = {}, Cummulative MR = {}'.format(experiment_count, is_backtrack_string, mimr, action_taken, perf_improvement, analytic_perf, current_perf, elapsed_time, cumm_mr))
 
         # Append results to log file
         with open("experiment_logs.txt", "a") as myfile:
@@ -478,7 +479,7 @@ def print_all_steps(redis_db, total_experiments, sys_config, workload_config, fi
             myfile.write(log_msg)
 
         net_improvement += float(perf_improvement)
-    print 'Net Improvement: {}'.format(net_improvement)
+    logging.info('Net Improvement: {}'.format(net_improvement))
 
     with open("experiment_logs.txt", "a") as myfile:
         myfile.write('net_improvement,{}\n'.format(net_improvement))
@@ -499,7 +500,7 @@ def print_csv_configuration(final_configuration, output_csv='tuned_config.csv'):
 
 # Iterate through all the colocated imrs of the same resource
 def find_colocated_nimrs(redis_db, imr, mr_working_set, baseline_mean, sys_config, workload_config):
-    print 'Finding colocated NIMRs'
+    logging.info('Finding colocated NIMRs')
     experiment_trials = sys_config['trials']
     stress_weight = sys_config['stress_weight']
 
@@ -513,17 +514,17 @@ def find_colocated_nimrs(redis_db, imr, mr_working_set, baseline_mean, sys_confi
     for deployment in imr.instances:
         vm_ip, container = deployment
         colocated_services = colocated_services + vm_to_service[vm_ip]
-    print 'Colocated services are {}'.format(colocated_services)
+    logging.info('Colocated services are {}'.format(colocated_services))
 
     candidate_mrs = []
     for mr in mr_working_set:
         if mr.service_name in colocated_services and mr.resource == imr.resource:
             candidate_mrs.append(mr)
-    print 'Candidate MRs are {}'.format([mr.to_string() for mr in candidate_mrs])
+    logging.info('Candidate MRs are {}'.format([mr.to_string() for mr in candidate_mrs]))
 
     nimr_list = []
     for mr in candidate_mrs:
-        print 'MR being considered is {}'.format(mr.to_string())
+        logging.info('MR being considered is {}'.format(mr.to_string()))
         mr_gradient_schedule = calculate_mr_gradient_schedule(redis_db, [mr],
                                                               sys_config,
                                                               stress_weight)
@@ -537,9 +538,9 @@ def find_colocated_nimrs(redis_db, imr, mr_working_set, baseline_mean, sys_confi
 
         perf_diff = mean_result - baseline_mean
         if (perf_diff > 0.03 * baseline_mean) and optimize_for_lowest:
-            print 'Do nothing for optimize lowest'
+            logging.info('Do nothing for optimize lowest')
         elif (perf_diff < -0.03 * baseline_mean) and optimize_for_lowest is False:
-            print 'Do nothing for optimize lowest'
+            logging.info('Do nothing for optimize lowest')
         else:
             nimr_list.append(mr)
 
@@ -587,9 +588,9 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
 
     killer = GracefulKiller(redis_db)
 
-    print '\n' * 2
-    print '*' * 20
-    print 'INFO: INITIALIZING RESOURCE CONFIG'
+    logging.info('\n' * 2)
+    logging.info('*' * 20)
+    logging.info('INITIALIZING RESOURCE CONFIG')
     # Initialize Redis and Cluster based on the default resource configuration
     init_cluster_capacities_r(redis_db, machine_type, quilt_overhead)
     init_service_placement_r(redis_db, default_mr_config)
@@ -610,19 +611,19 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
                 current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
                 new_mr_alloc = mr_improvement_proposal + current_mr_alloc
                 finalize_mr_provision(redis_db, mr, new_mr_alloc, workload_config)
-                print 'Maxing our resources for on-prem: MR {} increase from {} to {}'.format(mr.to_string(), current_mr_alloc, new_mr_alloc)
+                logging.info('Maxing our resources for on-prem: MR {} increase from {} to {}'.format(mr.to_string(), current_mr_alloc, new_mr_alloc))
                 
-    print 'Filled out resources for on-prem mode'
+    logging.info('Filled out resources for on-prem mode')
 
-    print '*' * 20
-    print 'INFO: INSTALLING DEPENDENCIES'
+    logging.info('*' * 20)
+    logging.info('INFO: INSTALLING DEPENDENCIES')
     install_dependencies(workload_config)
 
     # Initialize time for data charts
     time_start = datetime.datetime.now()
 
-    print '*' * 20
-    print 'INFO: RUNNING BASELINE'
+    logging.info('*' * 20)
+    logging.info('INFO: RUNNING BASELINE')
 
     current_performance = measure_baseline(workload_config,
                                            baseline_trials,
@@ -634,7 +635,7 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
     current_time_stop = datetime.datetime.now()
     time_delta = current_time_stop - time_start
 
-    print 'The Baseline performance is {}'.format(baseline_mean)
+    logging.info('The Baseline performance is {}'.format(baseline_mean))
     with open("reduction_log.txt", "a") as myfile:
         log_line = 'Starting a new iteration of CUTTING \n'
         log_line += 'All measurements are {}\n'.format(baseline_performance)
@@ -655,8 +656,8 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
     # Modified while condition for completion
     while experiment_count < num_iterations:
         recent_performance = -1
-        print '\n\n\n\n\n'
-        print 'Cutting round number {}'.format(experiment_count)
+        logging.info('\n\n\n\n\n')
+        logging.info('Cutting round number {}'.format(experiment_count))
         # Get a list of MRs to stress in the form of a list of MRs
         actions_taken = {}
         pipeline_to_consider = apply_filtering_policy(redis_db, mr_working_set, experiment_count,
@@ -679,10 +680,10 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
                 myfile.write('Step {}, no pipelines found, increasing partition size to {}\n'.format(experiment_count, new_partitions))
             continue
 
-        print 'Pipelines to consider are {}'.format(pipeline_to_consider)
+        logging.info('Pipelines to consider are {}'.format(pipeline_to_consider))
         # Iterate through the pipelines and keep clamping down on the pipelines
         for pipeline in pipeline_to_consider:
-            print 'Exploring pipeline {}'.format([mr.to_string() for mr in pipeline])
+            logging.info('Exploring pipeline {}'.format([mr.to_string() for mr in pipeline]))
             mr_new_allocation = {}
             mr_original_allocation = {}
             for mr in pipeline:
@@ -701,11 +702,11 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
                 # Revert the changes
                 for mr in pipeline:
                     resource_modifier.set_mr_provision(mr, mr_original_allocation[mr])
-                print 'Failed, trying a new filtering pipeline'
+                logging.warning('Failed, trying a new filtering pipeline')
             else:
                 # Commit the changes
                 for mr in pipeline:
-                    print 'MR {} cut from {} to {}'.format(mr.to_string(), mr_original_allocation[mr], mr_new_allocation[mr])
+                    logging.info('MR {} cut from {} to {}'.format(mr.to_string(), mr_original_allocation[mr], mr_new_allocation[mr]))
                     resource_datastore.write_mr_alloc(redis_db, mr, mr_new_allocation[mr])
                     update_machine_consumption(redis_db, mr, mr_original_allocation[mr], mr_new_allocation[mr])
                     actions_taken[mr] = mr_new_allocation[mr] - mr_original_allocation[mr]
@@ -731,8 +732,8 @@ def runClampdown(sys_config, workload_config, filter_config, default_mr_config, 
             result_string += 'IMR aware Packing has {} bins with placement {}\n'.format(len(imr_aware_packing.keys()), imr_aware_packing)
             for mr in actions_taken:
                 result_string += 'Action Taken for {} is {}\n'.format(mr.to_string(), actions_taken[mr])
-            print 'tuned_config.csv below'
-            print 'SERVICE,RESOURCE,AMOUNT,REPR\n'
+            logging.info('tuned_config.csv below')
+            logging.info('SERVICE,RESOURCE,AMOUNT,REPR\n')
             for mr in current_mr_config:
                 result_string += '{},{},{},RAW\n'.format(mr.service_name, mr.resource, current_mr_config[mr])
             result_string += '\n\n'
@@ -828,8 +829,8 @@ def squeeze_nimrs(redis_db, sys_config,
         nimr_results = measure_runtime(workload_config, experiment_trials)
         nimr_mean = mean_list(nimr_results[metric])
 
-        print 'Current performance is {}'.format(current_performance_mean)
-        print 'New performance is {}'.format(nimr_mean)
+        logging.info('Current performance is {}'.format(current_performance_mean))
+        logging.info('New performance is {}'.format(nimr_mean))
 
         is_constant_perf = is_performance_constant(nimr_mean, current_performance_mean, within_x=error_tolerance)
         is_improved_perf = is_performance_improved(nimr_mean, current_performance_mean,
@@ -839,14 +840,14 @@ def squeeze_nimrs(redis_db, sys_config,
 
         if should_retain_change:
             finalize_mr_provision(redis_db, nimr, new_alloc, workload_config)
-            print 'Successfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
+            logging.info('Successfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
                                                                              current_nimr_alloc,
-                                                                             new_alloc)
+                                                                             new_alloc))
             successful_steal.append(nimr)
         else:
-            print 'Unsuccessfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
+            logging.info('Unsuccessfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
                                                                                current_nimr_alloc,
-                                                                               new_alloc)
+                                                                               new_alloc))
             resource_modifier.set_mr_provision(nimr, current_nimr_alloc, None)
 
     return successful_steal
@@ -884,7 +885,7 @@ def backtrack_overstep(redis_db, workload_config, experiment_count,
                                                0, 0, is_backtrack=True)
 
             results = tbot_datastore.read_summary_redis(redis_db, experiment_count)
-            print 'Results from backtrack are {}'.format(results)
+            logging.info('Results from backtrack are {}'.format(results))
             return median_alloc_perf
         else:
             # Revert to the most recent MR allocation
@@ -936,12 +937,12 @@ def parse_clampdown_config_file(config_file):
     if len(known_imr_service) != 0 and known_imr_service[0] != '':
         for service_name in known_imr_service:
             if service_name not in all_services:
-                print 'Invalid service name in [Basic] field {}'.format(service_name)
+                logging.error('Invalid service name in [Basic] field {}'.format(service_name))
                 exit()
 
         for resource in known_imr_resource:
             if resource not in all_resources:
-                print 'Invalid resource name in [Basic] field {}'.format(resource)
+                logging.error('Invalid resource name in [Basic] field {}'.format(resource))
                 exit()
 
         vm_list = get_actual_vms()
@@ -960,20 +961,20 @@ def parse_clampdown_config_file(config_file):
     if fill_services_first == '':
         sys_config['fill_services_first'] = None
         if sys_config['setting_mode'] == 'prem':
-            print 'You need to specify some services to try to fill first!'
+            logging.error('You need to specify some services to try to fill first!')
             exit()
     else:
         sys_config['fill_services_first'] = fill_services_first.split(',')
         for service in sys_config['fill_services_first']:
             if service not in all_services:
-                print 'Invalid service name {}. Change your field fill_services_first'.format(service)
+                logging.error('Invalid service name {}. Change your field fill_services_first'.format(service))
                 exit()
 
     # Configuration parameters relating to the filter step
     filter_config['filter_policy'] = config.get('Filter', 'filter_policy')
     assert filter_config['filter_policy'] == 'pipeline' or filter_config['filter_policy'] == 'pipeline_clampdown' or filter_config['filter_policy'] == ''
     if filter_config['filter_policy'] != 'pipeline_clampdown':
-        print 'Are you sure the Filter policy should not be pipeline_clampdown? Exiting..'
+        logging.error('Are you sure the Filter policy should not be pipeline_clampdown? Exiting..')
         exit()
     
     if filter_config['filter_policy'] == '':
@@ -1052,7 +1053,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
             max_capacity = get_instance_specs(machine_type)[mr.resource]
             default_raw_alloc = (default_alloc_percentage / 100.0) * max_capacity
             mr_allocation[mr] = default_raw_alloc
-        print mr_allocation
+        logging.info(mr_allocation)
     else:
         # Manual Configuration Possible
         # Parse a CSV
@@ -1070,7 +1071,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
                 # Convert REPR to RAW AMOUNT
                 if amount_repr == 'PERCENT':
                     if amount <= 0 or amount > 100:
-                        print 'Error: invalid default percentage. Exiting...'
+                        logging.error('Error: invalid default percentage. Exiting...')
                         exit()
                     max_capacity = get_instance_specs(machine_type)[resource]
                     amount = (amount / 100.0) * max_capacity
@@ -1098,7 +1099,7 @@ def validate_configs(sys_config, workload_config):
         if resource in ['CPU-CORE', 'CPU-QUOTA', 'DISK', 'NET', 'MEMORY', '*']:
             continue
         else:
-            print 'Cannot stress a specified resource: {}'.format(resource)
+            logging.warning('Cannot stress a specified resource: {}'.format(resource))
 
 #Possibly will need to be changed as we start using hostnames in Quilt
 def validate_ip(ip_addresses):
@@ -1106,7 +1107,7 @@ def validate_ip(ip_addresses):
         try:
             socket.inet_aton(ip)
         except:
-            print 'The IP Address {} is Invalid'.format(ip)
+            logging.error('The IP Address {} is Invalid'.format(ip))
             exit()
 
 # Installs dependencies on machines if needed
@@ -1125,7 +1126,7 @@ def install_dependencies(workload_config):
     # Hardcoded for apt-app, initializing databases
     if workload_config['type'] == 'apt-app':
         # if len(traffic_machines) != 6:
-        #     print 'Not enough traffic machines supplied. Please check config file. Exiting...'
+        #     logging.error('Not enough traffic machines supplied. Please check config file. Exiting...')
         #     exit()
         # for traffic_machine in traffic_machines:
         #     traffic_client = get_client(traffic_machine)
@@ -1156,7 +1157,7 @@ def filter_mr(mr_allocation, acceptable_resources, acceptable_services, acceptab
         # and it is hard to solve...
 
     for mr in delete_queue:
-        print 'Deleting MR: ', mr.to_string()
+        logging.info('Deleting MR: ', mr.to_string())
         del mr_allocation[mr]
 
     return mr_allocation
@@ -1194,11 +1195,11 @@ if __name__ == "__main__":
             'spark.cores.max': '48'
         }
         workload_config['instances'] = service_to_deployment['hantaowang/bcd-spark'] + service_to_deployment['hantaowang/bcd-spark-master']
-        print workload_config
+        logging.info(workload_config)
         
     experiment_start = time.time()
     runClampdown(sys_config, workload_config, filter_config, mr_allocation, args.last_completed_iter)
     experiment_end = time.time()
 
     # Record the time and the number of MRs visited
-    print 'The experiment runs for a total of {}'.format(experiment_end - experiment_start)
+    logging.info('The experiment runs for a total of {}'.format(experiment_end - experiment_start))

--- a/src/run_clampdown.py
+++ b/src/run_clampdown.py
@@ -1071,7 +1071,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
                 # Convert REPR to RAW AMOUNT
                 if amount_repr == 'PERCENT':
                     if amount <= 0 or amount > 100:
-                        logging.error('Error: invalid default percentage. Exiting...')
+                        logging.error('invalid default percentage. Exiting...')
                         exit()
                     max_capacity = get_instance_specs(machine_type)[resource]
                     amount = (amount / 100.0) * max_capacity

--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -129,7 +129,7 @@ def measure_bcd(workload_configuration, experiment_iterations):
 
     close_client(ssh_client)
 
-    logging.info(latency.latency, x[0])
+    logging.info("{}, {}".format(latency.latency, x[0]))
     return {'latency': x,
             'latency_50': x,
             'latency_99': x,

--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -7,6 +7,8 @@ from measure_performance_MEAN_py3 import *
 from run_spark_streaming import *
 import numpy as np
 
+import logging
+
 # Measure the performance of the application in term of latency
 # Note: Although unused in some experiments, container_id was included to maintain symmetry
 def measure_runtime(workload_config, experiment_iterations, include_warmups=False):
@@ -32,7 +34,7 @@ def measure_runtime(workload_config, experiment_iterations, include_warmups=Fals
     elif experiment_type == 'bcd':
         return measure_bcd(workload_config, experiment_iterations)
     else:
-        print 'INVALID EXPERIMENT TYPE: {}'.format(experiment_type)
+        logging.error('INVALID EXPERIMENT TYPE: {}'.format(experiment_type))
         exit()
 
 #Resets all parameters of the experiment to default values
@@ -42,17 +44,17 @@ def reset_experiment(vm_ip, container_id):
     try:
         clear_all_entries(vm_ip)
     except:
-        print ("Couldn't reset VM {}".format(vm_ip))
+        logging.warning("Couldn't reset VM {}".format(vm_ip))
     close_client(ssh_client)
 
 def execute_parse_results(ssh_client, cmd):
     _, results, _ = ssh_client.exec_command(cmd)
     try:
         results_str = results.read()
-        # print 'string', results_str
+        # logging.info('string', results_str)
         results_float = float(results_str.strip('\n'))
     except:
-        # print results.read()
+        # logging.info(results.read())
         results_float = -1
     return results_float
 
@@ -77,7 +79,7 @@ class latencyResult():
     def failure(self):
         for i in range(0, len(self.success)):
             if self.success[i] == False:
-                print "FAILURE: index {0} was False".format(i)
+                logging.warning("FAILURE: index {0} was False".format(i))
                 return i
         return -1
 
@@ -94,7 +96,7 @@ def median(lst):
 
 def is_finished(latency, experiment_iterations):
     if len(latency) < experiment_iterations:
-        print "LENGTH: latency is only {0} items but needs {1}".format(len(latency), experiment_iterations)
+        logging.warning("LENGTH: latency is only {0} items but needs {1}".format(len(latency), experiment_iterations))
         return len(latency)
     elif latency.failure() != -1:
         return latency.failure()
@@ -113,21 +115,21 @@ def measure_bcd(workload_configuration, experiment_iterations):
     stop = is_finished(latency, experiment_iterations)
 
     while stop != -1:
-        print 'docker exec -ti {0} sh -c "{1}  > ~/out.txt"'.format(traffic_generate_container, cmd)
+        logging.info('docker exec -ti {0} sh -c "{1}  > ~/out.txt"'.format(traffic_generate_container, cmd))
         _, results, error = ssh_client.exec_command(
             'docker exec {0} sh -c "{1} > ~/out.txt"'.format(traffic_generate_container, cmd))
         status = results.channel.recv_exit_status()
-        print "Test command was run successfully: {0}".format(status == 0)
-        print  parse_cmd.format(traffic_generate_container)
+        logging.info("Test command was run successfully: {0}".format(status == 0))
+        logging.info(parse_cmd.format(traffic_generate_container))
         r = execute_parse_results(ssh_client, parse_cmd.format(traffic_generate_container))
-        print "Results: {0}".format(r)
+        logging.info("Results: {0}".format(r))
         latency.add(float(r), status == 0, stop)
         stop = is_finished(latency, experiment_iterations)
     x = [median(latency.latency)]
 
     close_client(ssh_client)
 
-    print latency.latency, x[0]
+    logging.info(latency.latency, x[0])
     return {'latency': x,
             'latency_50': x,
             'latency_99': x,
@@ -157,14 +159,14 @@ def measure_elk_stack(workload_configuration, experiment_iterations):
     stop = is_finished(latency, experiment_iterations)
 
     while stop != -1:
-        print 'docker exec -ti {0} sh -c "{1}  > ~/out.txt"'.format(traffic_generate_container, cmd)
+        logging.info('docker exec -ti {0} sh -c "{1}  > ~/out.txt"'.format(traffic_generate_container, cmd))
         _, results, error = ssh_client.exec_command(
             'docker exec {0} sh -c "{1} > ~/out.txt"'.format(traffic_generate_container, cmd))
         status = results.channel.recv_exit_status()
-        print "Test command was run successfully: {0}".format(status == 0)
-        print parse_cmd.format(traffic_generate_container)
+        logging.info("Test command was run successfully: {0}".format(status == 0))
+        logging.info(parse_cmd.format(traffic_generate_container))
         r = execute_parse_results(ssh_client, parse_cmd.format(traffic_generate_container))
-        print "Results: {0}".format(r)
+        logging.info("Results: {0}".format(r))
         latency.add(float(r), status == 0, stop)
         stop = is_finished(latency, experiment_iterations)
     x = [median(latency.latency)]
@@ -172,14 +174,14 @@ def measure_elk_stack(workload_configuration, experiment_iterations):
     # Clear indices
     clear_cmd = 'curl -XDELETE http://elasticsearch.q:9200/*'
     docker_clear_cmd = 'docker exec -ti {} sh -c "{}"'.format(traffic_generate_container, clear_cmd)
-    print docker_clear_cmd
+    logging.info(docker_clear_cmd)
     _, results, error = ssh_client.exec_command(docker_clear_cmd)
     status = results.channel.recv_exit_status()
-    print 'Clearing Index status: {}'.format(status == 0)
+    logging.info('Clearing Index status: {}'.format(status == 0))
     
     close_client(ssh_client)
 
-    print latency.latency, x[0]
+    logging.info(latency.latency, x[0])
     return {'latency': x,
             'latency_50': x,
             'latency_99': x,
@@ -211,7 +213,7 @@ def measure_nginx_single_machine(workload_configuration, experiment_iterations):
 
     for x in range(experiment_iterations):
         benchmark_cmd = 'ab -n {} -c {} -e results_file http://{}/ > output.txt'.format(NUM_REQUESTS, CONCURRENCY, nginx_public_ip)
-        print benchmark_cmd
+        logging.info(benchmark_cmd)
         _, results, _ = ssh_client.exec_command(benchmark_cmd)
         results.read()
 
@@ -258,23 +260,23 @@ def measure_ml_matrix(workload_configuration, experiment_iterations):
 
     execute_spark_job = 'docker exec {} {}'.format(container_name, spark_submit_cmd)
     #execute_spark_job = 'docker exec {} {}'.format(container_name.read().strip('\n'), spark_submit_cmd)
-    print execute_spark_job
+    logging.info(execute_spark_job)
 
     #Run the experiment experiment_iteration number of times
     for x in range(experiment_iterations):
         _, runtime, _ = ssh_client.exec_command(execute_spark_job)
-        print 'about to print the runtime read'
+        logging.info('about to print the runtime read')
         result_time = runtime.read()
-        print result_time
+        logging.info(result_time)
         try:
             runtime = int(re.findall(r'\d+',  result_time)[0])
         except IndexError:
-            print 'Spark out of memory!'
+            logging.warning('Spark out of memory!')
             all_results['latency'].append(0)
             continue
         all_results['latency'].append(runtime)
 
-    print all_results
+    logging.info(all_results)
 
     return all_results
 
@@ -300,7 +302,7 @@ def measure_TODO_response_time(workload_configuration, iterations):
 
     for x in range(iterations):
         _, results,_ = traffic_client.exec_command(post_cmd)
-        print post_cmd
+        logging.info(post_cmd)
         results.read()
 
         rps_cmd = 'cat output.txt | grep \'Requests per second\' | awk {{\'print $4\'}}'
@@ -320,7 +322,7 @@ def measure_TODO_response_time(workload_configuration, iterations):
 
     close_client(traffic_client)
 
-    print all_requests
+    logging.info(all_requests)
     return all_requests
 
 #Measure response time for MEAN Application
@@ -358,7 +360,7 @@ def measure_GET_response_time(workload_configuration, iterations):
         # benchmark_cmd = 'ab -n {} -c {} -s 999999 -e results_file http://{}/ > output.txt'.format(NUM_REQUESTS,
         #                                                                                            CONCURRENCY,
         #                                                                                            disknet_public_ip)
-        # print benchmark_cmd
+        # logging.info(benchmark_cmd)
         # _, results, _ = traffic_client.exec_command(benchmark_cmd)
         # results.read()
         #
@@ -375,7 +377,7 @@ def measure_GET_response_time(workload_configuration, iterations):
         # all_requests['rps'].append(execute_parse_results(traffic_client, rps_cmd))
 
         benchmark_cmd = '(/usr/bin/time -f "%e" curl -so /dev/null {}) &> output.txt'.format(disknet_public_ip)
-        print benchmark_cmd
+        logging.info(benchmark_cmd)
         _, results, _ = traffic_client.exec_command(benchmark_cmd)
         results.read()
 
@@ -424,28 +426,28 @@ def measure_apt_app(workload_config, experiment_iterations):
     for x in range(experiment_iterations):
 
         # Initializing machine db
-        print 'Initializing Machines'
+        logging.info('Initializing Machines')
         init_cmd = 'ab -p post.json -T application/json -n {} -c {} -s 9999 -e results_file http://{}:80/app/psql/users/'.format(
             NUM_REQUESTS, CONCURRENCY, apt_app_public_ip)
-        print init_cmd
+        logging.info(init_cmd)
         # _, results, _ = traffic_clients[0].exec_command(init_cmd)
         _, results, _ = traffic_client.exec_command(init_cmd)
         init_cmd = 'ab -p post.json -T application/json -n {} -c {} -s 9999 -e results_file http://{}:80/app/mysql/users/'.format(
             NUM_REQUESTS, CONCURRENCY, apt_app_public_ip)
-        print init_cmd
+        logging.info(init_cmd)
         # _, results, _ = traffic_clients[0].exec_command(init_cmd)
         _, results, _ = traffic_client.exec_command(init_cmd)
 
-        print "Sleeping for 2 seconds"
+        logging.info("Sleeping for 2 seconds")
         sleep(2)
 
         # Checkpoint 1 (initialize machines)
-        # print 'Reached Checkpoint 1! Check all traffic machines for post.json and db for entries'
+        # logging.error('Reached Checkpoint 1! Check all traffic machines for post.json and db for entries')
         # exit()
 
         # Initiating requests
         for a in range(6):
-            print benchmark_commands[a]
+            logging.info(benchmark_commands[a])
             #traffic_clients[a].exec_command(benchmark_commands[a])
             traffic_client.exec_command(benchmark_commands[a])
             sleep(0.2)
@@ -454,7 +456,7 @@ def measure_apt_app(workload_config, experiment_iterations):
         finished = 0
         repetitions = 0
         # finished_benchmark_cmd = "cat output.txt | grep 'Requests per second' | awk {{'print $4'}}"
-        print 'Please ignore the following new lines (if any)'
+        logging.info('Please ignore the following new lines (if any)')
         sleep(5)
         while finished != 6:
             sleep(2)
@@ -462,9 +464,9 @@ def measure_apt_app(workload_config, experiment_iterations):
             finished = 0
             # Call again...
             if repetitions > 50:
-                print 'Calling commands again due to unresponsiveness'
+                logging.info('Calling commands again due to unresponsiveness')
                 for a in range(6):
-                    print benchmark_commands[a]
+                    logging.info(benchmark_commands[a])
                     # traffic_clients[a].exec_command(benchmark_commands[a])
                     traffic_client.exec_command(benchmark_commands[a])
                     sleep(0.2)
@@ -476,7 +478,7 @@ def measure_apt_app(workload_config, experiment_iterations):
                 # blah = execute_parse_results(traffic_clients[b], finished_benchmark_cmd)
                 complete = execute_parse_results(traffic_client, finished_benchmark_cmd)
                 sleep(0.3)
-                # print 'test', complete
+                # logging.info("test {}".format(complete))
                 if complete != -1:
                     finished += 1
                 else:
@@ -537,8 +539,8 @@ def measure_apt_app(workload_config, experiment_iterations):
             rm_out_cmd = 'rm output{}.txt'.format(c)
             traffic_client.exec_command(rm_out_cmd)
             sleep(0.3)
-            print '{},{},{},{},{}'.format(rpst, latencyt, latency_50t, latency_90t, latency_99t)
-        print 'total:{},{},{},{},{}'.format(rps, latency, latency_50, latency_90, latency_99)
+            logging.info('{},{},{},{},{}'.format(rpst, latencyt, latency_50t, latency_90t, latency_99t))
+        logging.info('total:{},{},{},{},{}'.format(rps, latency, latency_50, latency_90, latency_99))
 
         # Removing entries
         curl1 = 'curl -X "DELETE" http://{}:80/app/mysql/users'.format(apt_app_public_ip)
@@ -554,12 +556,12 @@ def measure_apt_app(workload_config, experiment_iterations):
         traffic_client.exec_command(curl2)
         sleep(0.3)
         traffic_client.exec_command(curl3)
-        print 'Sleeping for 15 seconds for proper deletion'
+        logging.info('Sleeping for 15 seconds for proper deletion')
         sleep(15)
         traffic_client.exec_command(curl1)
         traffic_client.exec_command(curl2)
 
-        print 'Sleeping for 5 more seconds for proper deletion'
+        logging.info('Sleeping for 5 more seconds for proper deletion')
         sleep(5)
 
         all_requests['rps'].append(rps)
@@ -571,8 +573,8 @@ def measure_apt_app(workload_config, experiment_iterations):
         # for client in traffic_clients:
         #     close_client(client)
         # close_client(traffic_client)
-        # print all_requests
-        # print 'Checkpoint 2, Baseline and iteration done'
+        # logging.info(all_requests)
+        # logging.info('Checkpoint 2, Baseline and iteration done')
         # exit()
 
     # Remove outliers (all outside of 1 standard deviation)

--- a/src/run_spark_streaming.py
+++ b/src/run_spark_streaming.py
@@ -203,7 +203,7 @@ def collect_results(instances, redis_instances, events_per_container):
             logging.info('All results received. Results are as follows: {}\n'.format(results))
             return results
         
-    logging.warning("Error: Something bad happened, so we need to flush out all the old messages")
+    logging.warning("Something bad happened, so we need to flush out all the old messages")
     logging.info("This will cause skew, so let's try a few things!")
     flush_redis(redis_instances)
     

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -872,8 +872,6 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         performance_improvement = simulated_mean - previous_mean
 
         # Write a summary of the experiment's iterations to Redis
-
-        logging.info("Writing summary, non-backtrack round {}".format(experiment_count))
         tbot_datastore.write_summary_redis(redis_db, experiment_count, effective_mimr,
                                            performance_improvement, action_taken,
                                            analytic_mean, improved_mean,
@@ -890,10 +888,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         # Checkpoint MR configurations and print
         current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
         print_csv_configuration(current_mr_config)
-
-        logging.info("Incrementing experiment_count {}".format(experiment_count))
         experiment_count += 1
-        logging.info("Incremented experiment_count {}".format(experiment_count))
 
         # Potentially adapt step size if no performance gains observed
         # Do this after step summary for easy debugging
@@ -907,7 +902,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             logging.info('Net performance improvement reported as 0, so initiating a backtrack step')
             new_performance = backtrack_overstep(redis_db,
                                                  workload_config,
-                                                 experiment_trials,
+                                                 experiment_count,
                                                  current_performance,
                                                  action_taken,
                                                  error_tolerance/2.0)
@@ -918,10 +913,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 # Checkpoint MR configurations and print
                 current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
                 print_csv_configuration(current_mr_config)
-
-                logging.info("Incrementing experiment_count {}".format(experiment_count))
                 experiment_count += 1
-                logging.info("Incremented experiment_count {}".format(experiment_count))
 
                 logging.info('Backtrack completed, referred to as experiment {}'.format(experiment_count))
 
@@ -1089,8 +1081,6 @@ def backtrack_overstep(redis_db, workload_config, experiment_count,
             perf_improvement = median_alloc_mean - current_perf_float
             new_action = {}
             new_action[mr] = median_alloc - new_mr_alloc
-
-            logging.info("Writing summary, backtrack round {}".format(experiment_count))
             tbot_datastore.write_summary_redis(redis_db, experiment_count, mr,
                                                perf_improvement, new_action,
                                                median_alloc_mean, median_alloc_mean,

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -872,6 +872,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         performance_improvement = simulated_mean - previous_mean
 
         # Write a summary of the experiment's iterations to Redis
+
+        logging.info("Writing summary, non-backtrack round {}".format(experiment_count))
         tbot_datastore.write_summary_redis(redis_db, experiment_count, effective_mimr,
                                            performance_improvement, action_taken,
                                            analytic_mean, improved_mean,
@@ -888,7 +890,10 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         # Checkpoint MR configurations and print
         current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
         print_csv_configuration(current_mr_config)
+
+        logging.info("Incrementing experiment_count {}".format(experiment_count))
         experiment_count += 1
+        logging.info("Incremented experiment_count {}".format(experiment_count))
 
         # Potentially adapt step size if no performance gains observed
         # Do this after step summary for easy debugging
@@ -913,7 +918,10 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 # Checkpoint MR configurations and print
                 current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
                 print_csv_configuration(current_mr_config)
+
+                logging.info("Incrementing experiment_count {}".format(experiment_count))
                 experiment_count += 1
+                logging.info("Incremented experiment_count {}".format(experiment_count))
 
                 logging.info('Backtrack completed, referred to as experiment {}'.format(experiment_count))
 
@@ -1081,6 +1089,8 @@ def backtrack_overstep(redis_db, workload_config, experiment_count,
             perf_improvement = median_alloc_mean - current_perf_float
             new_action = {}
             new_action[mr] = median_alloc - new_mr_alloc
+
+            logging.info("Writing summary, backtrack round {}".format(experiment_count))
             tbot_datastore.write_summary_redis(redis_db, experiment_count, mr,
                                                perf_improvement, new_action,
                                                median_alloc_mean, median_alloc_mean,

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -766,8 +766,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
 
             if baseline_constant is False:
                 logging.info("ERROR: System state has changed since baseline. Deviation greater than {0}%".format(acceptable_deviation * 100))
-                logging.info("Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance))
-                sys.exit("System state has changed since baseline."))
+                logging.info("Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance)))
+                sys.exit("System state has changed since baseline.")
 
         # Recover the results of the experiment from Redis
         sorted_mr_list = tbot_datastore.get_top_n_mimr(redis_db, experiment_count,

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -1292,7 +1292,7 @@ def install_dependencies(workload_config):
     # Hardcoded for apt-app, initializing databases
     if workload_config['type'] == 'apt-app':
         # if len(traffic_machines) != 6:
-        #     logging.info('Not enough traffic machines supplied. Please check config file. Exiting...'
+        #     logging.info('Not enough traffic machines supplied. Please check config file. Exiting...')
         #     exit()
         # for traffic_machine in traffic_machines:
         #     traffic_client = get_client(traffic_machine)

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -36,6 +36,7 @@ import redis_resource as resource_datastore
 import modify_resources as resource_modifier
 import visualizer as chart_generator
 
+import logging
 
 '''
 Signal Handler
@@ -1376,7 +1377,12 @@ if __name__ == "__main__":
     parser.add_argument("--config_file", help="Configuration File for Throttlebot Execution")
     parser.add_argument("--resource_config", help='Default Resource Allocation for Throttlebot')
     parser.add_argument("--last_completed_iter", type=int, default=0, help="Last iteration completed")
+    parser.add_argument("--log", help='Default Logging File')
     args = parser.parse_args()
+
+    # Setup Logging
+    logging.basicConfig(filename=args.log, level=logging.INFO)
+    logging.info('Started')
 
     sys_config, workload_config, filter_config = parse_config_file(args.config_file)
     mr_allocation = parse_resource_config_file(args.resource_config, sys_config)

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -38,6 +38,7 @@ import visualizer as chart_generator
 
 import logging
 
+
 '''
 Signal Handler
 '''
@@ -50,10 +51,10 @@ class GracefulKiller:
         signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     def exit_gracefully(self, signum, frame):
-        print 'NIMRs have now also been squeezed, printing final values.'
+        logging.info('NIMRs have now also been squeezed, printing final values.')
         current_mr_config = resource_datastore.read_all_mr_alloc(self.redis_db)
         for mr in current_mr_config:
-            print '{} = {}'.format(mr.to_string(), current_mr_config[mr])
+            logging.info('{} = {}'.format(mr.to_string(), current_mr_config[mr]))
 
         print_csv_configuration(current_mr_config)
         exit()
@@ -77,12 +78,12 @@ def init_service_placement_r(redis_db, default_mr_configuration):
 # Set the current resource configurations withi the actual containers
 # Data points in resource_config are expressed in percentage change
 def init_resource_config(redis_db, default_mr_config, machine_type, wc):
-    print 'Initializing the Resource Configurations in the containers'
+    logging.info('Initializing the Resource Configurations in the containers')
     instance_specs = get_instance_specs(machine_type)
     for mr in default_mr_config:
         new_resource_provision = int(default_mr_config[mr])
         if check_change_mr_viability(redis_db, mr, new_resource_provision)[0] is False:
-            print 'Initial Resource provisioning for {} is too much. Exiting...'.format(mr.to_string())
+            logging.error('Initial Resource provisioning for {} is too much. Exiting...'.format(mr.to_string()))
             exit()
 
         # Enact the change in resource provisioning
@@ -95,7 +96,7 @@ def init_resource_config(redis_db, default_mr_config, machine_type, wc):
 
 # Initializes the maximum capacity and current consumption of Quilt
 def init_cluster_capacities_r(redis_db, machine_type, quilt_overhead):
-    print 'Initializing the per machine capacities'
+    logging.info('Initializing the per machine capacities')
     resource_alloc = get_instance_specs(machine_type)
     min_alloc = get_instance_min_specs()
 
@@ -159,8 +160,8 @@ def seperate_mr(mr_list, baseline_performance, optimize_for_lowest, gradient_mod
     for mr_result in mr_list:
         mr,exp_performance = mr_result
         perf_diff = exp_performance - baseline_performance
-        print 'perf diff is {}'.format(perf_diff)
-        print 'leeway is {}'.format(within_x * baseline_performance)
+        logging.info('perf diff is {}'.format(perf_diff))
+        logging.info('leeway is {}'.format(within_x * baseline_performance))
 
         if is_performance_constant(baseline_performance, exp_performance, within_x):
             nimr_list.append(mr)
@@ -246,7 +247,7 @@ def check_decrease_mr_viability(redis_db, mr, proposed_change):
                 return False, 0
             return False, valid_change
     except KeyError:
-        print 'Invalid Resource'
+        logging.error('Invalid Resource')
         exit()
 
 # Allow the MR to fill out the remainder of the resources on the machine
@@ -271,8 +272,8 @@ def fill_out_resource(redis_db, imr):
             myfile.write(debug_statement)
 
     if improvement_proposal < 0:
-        print 'WARNING: Improvement proposal is less than 0 (it is {})'.format(improvement_proposal)
-        print 'Check out fill_out_resource_debug.txt to help diagnose the problem'
+        logging.warning('Improvement proposal is less than 0 (it is {})'.format(improvement_proposal))
+        logging.info('Check out fill_out_resource_debug.txt to help diagnose the problem')
 
         # get immediate results just by setting the proposal to zero in this case
         improvement_proposal = 0
@@ -286,13 +287,13 @@ def fill_out_resource(redis_db, imr):
 # In the NIMR list for NIMRs to be de-allocated.
 # Returns a list of NIMRs to reduce and the raw amount to reduce each NIMR, and the amount to incease the IMR bu
 def create_decrease_nimr_schedule(redis_db, imr, nimr_list, stress_weight, target_imr_increase):
-    print 'IMR is {}'.format(imr.to_string())
+    logging.info('IMR is {}'.format(imr.to_string()))
 
     pruned_nimr_list = []
     # Filter out NIMRs that are not the same resource type as mr
     for nimr in list(nimr_list):
-        print 'NIMR resource: {} '.format(nimr.resource)
-        print 'IMR resource: {}'.format(imr.resource)
+        logging.info('NIMR resource: {} '.format(nimr.resource))
+        logging.info('IMR resource: {}'.format(imr.resource))
         if nimr.resource == imr.resource: pruned_nimr_list.append(nimr)
 
     if len(pruned_nimr_list) == 0:
@@ -368,7 +369,7 @@ def create_decrease_nimr_schedule(redis_db, imr, nimr_list, stress_weight, targe
     machine_to_imr = containers_per_vm(imr)
     max_imr_containers = max([machine_to_imr[machine_ip] for machine_ip in machine_to_imr])
     proposed_imr_improvement = abs(min_vm_removal) / max_imr_containers
-    print 'proposed imr improvement is {}'.format(proposed_imr_improvement)
+    logging.info('proposed imr improvement is {}'.format(proposed_imr_improvement))
     assert proposed_imr_improvement >= 0
     if proposed_imr_improvement == 0:
         return {}, 0
@@ -391,7 +392,7 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
         new_alloc = convert_percent_to_raw(nimr, nimr_alloc, stress_weight)
 
         valid_change, valid_change_amount = check_change_mr_viability(redis_db, nimr, new_alloc - nimr_alloc)
-        print 'For NIMR {}, the valid change amount is {}'.format(nimr.to_string(), valid_change_amount)
+        logging.info('For NIMR {}, the valid change amount is {}'.format(nimr.to_string(), valid_change_amount))
         assert valid_change_amount <= 0
 
         if valid_change_amount == 0:
@@ -402,7 +403,7 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
                 continue
 
             vm_to_removal[vm_ip] += valid_change_amount * reduction_multiplier[vm_ip]
-            print 'For vm {}, we are adding {}'.format(vm_ip, valid_change_amount * reduction_multiplier[vm_ip])
+            logging.info('For vm {}, we are adding {}'.format(vm_ip, valid_change_amount * reduction_multiplier[vm_ip]))
 
         nimr_reduction[nimr] = valid_change_amount
         min_vm_removal = min([abs(vm_to_removal[vm_ip]) for vm_ip in vm_to_removal])
@@ -416,12 +417,12 @@ def determine_reallocation(redis_db, colocated_nimr_list, vm_to_nimr, imr,
 def simulate_mr_provisions(redis_db, imr, imr_proposal, nimr_diff_proposal):
     for nimr in nimr_diff_proposal:
         new_nimr_alloc = resource_datastore.read_mr_alloc(redis_db, nimr) + nimr_diff_proposal[nimr]
-        print 'Changing NIMR {} from {} to {}'.format(nimr.to_string(), resource_datastore.read_mr_alloc(redis_db, nimr), new_nimr_alloc)
+        logging.info('Changing NIMR {} from {} to {}'.format(nimr.to_string(), resource_datastore.read_mr_alloc(redis_db, nimr), new_nimr_alloc))
         set_mr_provision_detect_id_change(redis_db, nimr, int(new_nimr_alloc), None)
 
     old_imr_alloc = resource_datastore.read_mr_alloc(redis_db, imr)
     new_imr_alloc = old_imr_alloc + imr_proposal
-    print 'changing imr from {} to {}'.format(old_imr_alloc, new_imr_alloc)
+    logging.info('changing imr from {} to {}'.format(old_imr_alloc, new_imr_alloc))
     set_mr_provision_detect_id_change(redis_db, imr, int(new_imr_alloc), None)
 
 # Revert to nimr allocation to most recently committed values, reverts "simulation"
@@ -476,7 +477,7 @@ def update_mr_config(redis_db, mr_in_play):
 
 # Prints all improvements attempted by Throttlebot
 def print_all_steps(redis_db, total_experiments, sys_config, workload_config, filter_config):
-    print 'Steps towards improving performance'
+    logging.info('Steps towards improving performance')
     net_improvement = 0
 
     with open("experiment_logs.txt", "a") as myfile:
@@ -489,7 +490,7 @@ def print_all_steps(redis_db, total_experiments, sys_config, workload_config, fi
         if is_backtrack == 'True':
             is_backtrack_string = 'backtrack'
 
-        print 'Iteration {}_{}, Mimr = {}, New allocation = {}, Performance Improvement = {}, Analytic Performance = {}, Performance after improvement = {}, Elapsed Time = {}, Cummulative MR = {}'.format(experiment_count, is_backtrack_string, mimr, action_taken, perf_improvement, analytic_perf, current_perf, elapsed_time, cumm_mr)
+        logging.info('Iteration {}_{}, Mimr = {}, New allocation = {}, Performance Improvement = {}, Analytic Performance = {}, Performance after improvement = {}, Elapsed Time = {}, Cummulative MR = {}'.format(experiment_count, is_backtrack_string, mimr, action_taken, perf_improvement, analytic_perf, current_perf, elapsed_time, cumm_mr))
 
         # Append results to log file
         with open("experiment_logs.txt", "a") as myfile:
@@ -497,7 +498,7 @@ def print_all_steps(redis_db, total_experiments, sys_config, workload_config, fi
             myfile.write(log_msg)
 
         net_improvement += float(perf_improvement)
-    print 'Net Improvement: {}'.format(net_improvement)
+    logging.info('Net Improvement: {}'.format(net_improvement))
 
     with open("experiment_logs.txt", "a") as myfile:
         myfile.write('net_improvement,{}\n'.format(net_improvement))
@@ -519,7 +520,7 @@ def print_csv_configuration(final_configuration, output_csv='tuned_config.csv'):
 # Iterate through all the colocated imrs of the same resource
 # Will not work correctly for inverted gradient!!!!!
 def find_colocated_nimrs(redis_db, imr, mr_working_set, baseline_mean, sys_config, workload_config):
-    print 'Finding colocated NIMRs'
+    logging.info('Finding colocated NIMRs')
     experiment_trials = sys_config['trials']
     stress_weight = sys_config['stress_weight']
     error_tolerance = sys_config['error_tolerance']
@@ -534,17 +535,17 @@ def find_colocated_nimrs(redis_db, imr, mr_working_set, baseline_mean, sys_confi
     for deployment in imr.instances:
         vm_ip, container = deployment
         colocated_services = colocated_services + vm_to_service[vm_ip]
-    print 'Colocated services are {}'.format(colocated_services)
+    logging.info('Colocated services are {}'.format(colocated_services))
 
     candidate_mrs = []
     for mr in mr_working_set:
         if mr.service_name in colocated_services and mr.resource == imr.resource:
             candidate_mrs.append(mr)
-    print 'Candidate MRs are {}'.format([mr.to_string() for mr in candidate_mrs])
+    logging.info('Candidate MRs are {}'.format([mr.to_string() for mr in candidate_mrs]))
 
     nimr_list = []
     for mr in candidate_mrs:
-        print 'MR being considered is {}'.format(mr.to_string())
+        logging.info('MR being considered is {}'.format(mr.to_string()))
 
         mr_gradient_schedule = calculate_mr_gradient_schedule(redis_db, [mr],
                                                               sys_config,
@@ -612,9 +613,9 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
 
     killer = GracefulKiller(redis_db)
 
-    print '\n' * 2
-    print '*' * 20
-    print 'INFO: INITIALIZING RESOURCE CONFIG'
+    logging.info('\n' * 2)
+    logging.info('*' * 20)
+    logging.info('INITIALIZING RESOURCE CONFIG')
     # Initialize Redis and Cluster based on the default resource configuration
     init_cluster_capacities_r(redis_db, machine_type, quilt_overhead)
     init_service_placement_r(redis_db, default_mr_config)
@@ -635,18 +636,18 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 current_mr_alloc = resource_datastore.read_mr_alloc(redis_db, mr)
                 new_mr_alloc = mr_improvement_proposal + current_mr_alloc
                 finalize_mr_provision(redis_db, mr, new_mr_alloc, workload_config)
-                print 'Maxing our resources for on-prem: MR {} increase from {} to {}'.format(mr.to_string(), current_mr_alloc, new_mr_alloc)
-    print 'Filled out resources for on-prem mode'
+                logging.info('Maxing our resources for on-prem: MR {} increase from {} to {}'.format(mr.to_string(), current_mr_alloc, new_mr_alloc))
+    logging.info('Filled out resources for on-prem mode')
 
-    print '*' * 20
-    print 'INFO: INSTALLING DEPENDENCIES'
+    logging.info('*' * 20)
+    logging.info('INSTALLING DEPENDENCIES')
     install_dependencies(workload_config)
 
     # Initialize time for data charts
     time_start = datetime.datetime.now()
 
-    print '*' * 20
-    print 'INFO: RUNNING BASELINE'
+    logging.info('*' * 20)
+    logging.info('RUNNING BASELINE')
 
     # Get the Current Performance -- not used for any analysis, just to benchmark progress!!
     current_performance = measure_baseline(workload_config,
@@ -658,7 +659,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
     current_time_stop = datetime.datetime.now()
     time_delta = current_time_stop - time_start
 
-    print 'Current (non-analytic) performance measured: {}'.format(current_performance)
+    logging.info('Current (non-analytic) performance measured: {}'.format(current_performance))
 
     if last_completed_iter == 0:
         tbot_datastore.write_summary_redis(redis_db,
@@ -670,8 +671,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                                            mean_list(current_performance[preferred_performance_metric]),
                                            time_delta.seconds, 0)
 
-    print '============================================'
-    print '\n' * 2
+    logging.info('============================================')
+    logging.info('\n' * 2)
 
     # Initialize the current configurations
     # Initialize the working set of MRs to all the MRs
@@ -690,7 +691,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         # Calculate the analytic baseline that is used to determine MRs
 
         analytic_provisions = prepare_analytic_baseline(redis_db, sys_config, stress_weight)
-        print 'The Analytic provisions are as follows {}'.format(analytic_provisions)
+        logging.info('The Analytic provisions are as follows {}'.format(analytic_provisions))
         for change_mr in analytic_provisions:
             set_mr_provision_detect_id_change(redis_db, change_mr, analytic_provisions[change_mr], workload_config)
 
@@ -700,8 +701,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             analytic_baseline = deepcopy(current_performance)
 
         analytic_mean = mean_list(analytic_baseline[preferred_performance_metric])
-        print 'The analytic baseline is {}'.format(analytic_baseline)
-        print 'This current performance is {}'.format(current_performance)
+        logging.info('The analytic baseline is {}'.format(analytic_baseline))
+        logging.info('This current performance is {}'.format(current_performance))
         analytic_baseline[preferred_performance_metric] = remove_outlier(analytic_baseline[preferred_performance_metric])
 
         # Get a list of MRs to stress in the form of a list of MRs
@@ -709,12 +710,12 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                                                 sys_config, workload_config, filter_config)
 
         for mr in mr_to_consider:
-            print '\n' * 2
-            print '*' * 20
-            print 'Current MR is {}'.format(mr.to_string())
+            logging.info('\n' * 2)
+            logging.info('*' * 20)
+            logging.info('Current MR is {}'.format(mr.to_string()))
             increment_to_performance = {}
             current_mr_allocation = resource_datastore.read_mr_alloc(redis_db, mr)
-            print 'Current MR allocation is {}'.format(current_mr_allocation)
+            logging.info('Current MR allocation is {}'.format(current_mr_allocation))
 
             # Calculate Gradient Schedule and provision resources accordingly
             mr_gradient_schedule = calculate_mr_gradient_schedule(redis_db, [mr],
@@ -743,8 +744,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             # Write the results of the iteration to Redis
             tbot_datastore.write_redis_results(redis_db, mr, increment_to_performance,
                                                experiment_count, preferred_performance_metric)
-            print '*' * 20
-            print '\n' * 2
+            logging.info('*' * 20)
+            logging.info('\n' * 2)
 
         # Timing Information for the purpose of experiments
         current_time_stop = datetime.datetime.now()
@@ -758,15 +759,15 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
 
         # If set, reruns the baseline as a sanity check before the IMR, MIMR is calculated
         if rerun_baseline:
-            print "\n\nRunning Baseline Again as Sanity Check"
+            logging.info("\n\nRunning Baseline Again as Sanity Check")
             acceptable_baseline = 0.3
             baseline_constant = is_baseline_constant(mr_working_set, workload_config, sys_config,
                                                     baseline_performance, acceptable_baseline)
 
             if baseline_constant is False:
-                print "ERROR: System state has changed since baseline. Deviation greater than {0}%".format(acceptable_deviation * 100)
-                print "Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance))
-                sys.exit("System state has changed since baseline.")
+                logging.info("ERROR: System state has changed since baseline. Deviation greater than {0}%".format(acceptable_deviation * 100))
+                logging.info("Current: {0}, Initial: {1}".format(mean_list(performance), mean_list(baseline_performance))
+                sys.exit("System state has changed since baseline."))
 
         # Recover the results of the experiment from Redis
         sorted_mr_list = tbot_datastore.get_top_n_mimr(redis_db, experiment_count,
@@ -793,8 +794,8 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             current_mimr = sorted_mr_list[mr_index][0]
             nimr_list = [nimr_tuple[0] for nimr_tuple in sorted_mr_list[mr_index+1:][::-1]]
 
-            print 'Current MIMR is {}'.format(current_mimr.to_string())
-            print 'NIMR list consists of {}'.format([nimr.to_string() for nimr in nimr_list])
+            logging.info('Current MIMR is {}'.format(current_mimr.to_string()))
+            logging.info('NIMR list consists of {}'.format([nimr.to_string() for nimr in nimr_list]))
 
             action_taken = {}
 
@@ -814,9 +815,9 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
 				                                                       imr_improvement_proposal,
                                                                                        stress_weight)
 
-            print 'IMR improvement proposal is {}'.format(imr_improvement_proposal)
+            logging.info('IMR improvement proposal is {}'.format(imr_improvement_proposal))
             for nimr in nimr_diff_proposal:
-                print 'The nimr decrease for {} is {}'.format(nimr.to_string(), nimr_diff_proposal[nimr])
+                logging.info('The nimr decrease for {} is {}'.format(nimr.to_string(), nimr_diff_proposal[nimr]))
 
             # Apply special handling in the scenario that a filter_policy has been set
             if filter_policy is not None and imr_improvement_proposal <= 0:
@@ -848,12 +849,12 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             is_perf_constant = is_performance_constant(current_perf_mean, simulated_mean, within_x=error_tolerance)
 
             if (is_perf_improved or is_perf_constant) is False:
-                print 'Performance went from {} to {}, thus continuing'.format(current_perf_mean, simulated_mean)
+                logging.info('Performance went from {} to {}, thus continuing'.format(current_perf_mean, simulated_mean))
                 revert_simulate_mr_provisions(redis_db, current_mimr, nimr_diff_proposal)
                 action_taken[current_mimr] = 0
                 continue
             else:
-                print 'Performance is constant or improved, so committing the changes'
+                logging.info('Performance is constant or improved, so committing the changes')
                 commit_mr_provision(redis_db, current_mimr, imr_improvement_proposal, nimr_diff_proposal)
                 action_taken = nimr_diff_proposal
                 action_taken[current_mimr] = imr_improvement_proposal
@@ -861,7 +862,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 break
 
         if effective_mimr is None:
-            print 'There is no NIMR stealing arrangement that makes sense here. Exiting...'
+            logging.error('There is no NIMR stealing arrangement that makes sense here. Exiting...')
             exit()
 
         # Test the new performance after potential resource stealing
@@ -882,7 +883,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
         chart_generator.get_summary_performance_charts(redis_db, workload_config, experiment_count, time_start)
 
         results = tbot_datastore.read_summary_redis(redis_db, experiment_count)
-        print 'Results from iteration {} are {}'.format(experiment_count, results)
+        logging.info('Results from iteration {} are {}'.format(experiment_count, results))
 
         # Checkpoint MR configurations and print
         current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
@@ -898,7 +899,7 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
             sys_config['baseline_trials'] = baseline_trials
             sys_config['trials'] = experiment_trials
             
-            print 'Net performance improvement reported as 0, so initiating a backtrack step'
+            logging.info('Net performance improvement reported as 0, so initiating a backtrack step')
             new_performance = backtrack_overstep(redis_db,
                                                  workload_config,
                                                  experiment_trials,
@@ -914,24 +915,24 @@ def run(sys_config, workload_config, filter_config, default_mr_config, last_comp
                 print_csv_configuration(current_mr_config)
                 experiment_count += 1
 
-                print 'Backtrack completed, referred to as experiment {}'.format(experiment_count)
+                logging.info('Backtrack completed, referred to as experiment {}'.format(experiment_count))
 
         print_all_steps(redis_db, experiment_count, sys_config, workload_config, filter_config)
 
-    print 'Convergence achieved - start squeezing NIMRs'
+    logging.info('Convergence achieved - start squeezing NIMRs')
 
     successful_steal = recent_nimr_list
     # Tentatively do this only 5 times to save time
     for x in range(5):
-        print 'Remaining nimrs to be stolen are {}'.format([mr.to_string() for mr in successful_steal])
+        logging.info('Remaining nimrs to be stolen are {}'.format([mr.to_string() for mr in successful_steal]))
         sucessful_steal = squeeze_nimrs(redis_db, sys_config,
                                         workload_config, successful_steal,
                                         current_performance)
 
-    print 'NIMRs have now also been squeezed, printing final values.'
+    logging.info('NIMRs have now also been squeezed, printing final values.')
     current_mr_config = resource_datastore.read_all_mr_alloc(redis_db)
     for mr in current_mr_config:
-        print '{} = {}'.format(mr.to_string(), current_mr_config[mr])
+        logging.info('{} = {}'.format(mr.to_string(), current_mr_config[mr]))
 
     print_csv_configuration(current_mr_config)
 
@@ -1023,8 +1024,8 @@ def squeeze_nimrs(redis_db, sys_config,
         nimr_results = measure_runtime(workload_config, experiment_trials)
         nimr_mean = mean_list(nimr_results[metric])
 
-        print 'Current performance is {}'.format(current_performance_mean)
-        print 'New performance is {}'.format(nimr_mean)
+        logging.info('Current performance is {}'.format(current_performance_mean))
+        logging.info('New performance is {}'.format(nimr_mean))
 
         is_constant_perf = is_performance_constant(nimr_mean, current_performance_mean, within_x=error_tolerance)
         is_improved_perf = is_performance_improved(nimr_mean, current_performance_mean,
@@ -1034,14 +1035,14 @@ def squeeze_nimrs(redis_db, sys_config,
 
         if should_retain_change:
             finalize_mr_provision(redis_db, nimr, new_alloc, workload_config)
-            print 'Successfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
+            logging.info('Successfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
                                                                              current_nimr_alloc,
-                                                                             new_alloc)
+                                                                             new_alloc))
             successful_steal.append(nimr)
         else:
-            print 'Unsuccessfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
+            logging.info('Unsuccessfully cut resources from NIMR {}: {} to {}'.format(nimr.to_string(),
                                                                                current_nimr_alloc,
-                                                                               new_alloc)
+                                                                               new_alloc))
             set_mr_provision_detect_id_change(redis_db, nimr, current_nimr_alloc, None)
 
     return successful_steal
@@ -1086,7 +1087,7 @@ def backtrack_overstep(redis_db, workload_config, experiment_count,
                                                0, 0, is_backtrack=True)
 
             results = tbot_datastore.read_summary_redis(redis_db, experiment_count)
-            print 'Results from backtrack are {}'.format(results)
+            logging.info('Results from backtrack are {}'.format(results))
             return median_alloc_perf
         else:
             # Revert to the most recent MR allocation
@@ -1131,14 +1132,14 @@ def parse_config_file(config_file):
     if fill_services_first == '':
         sys_config['fill_services_first'] = None
         if sys_config['setting_mode'] == 'prem':
-            print 'You need to specify some services to try to fill first!'
+            logging.error('You need to specify some services to try to fill first!')
             exit()
     else:
         sys_config['fill_services_first'] = fill_services_first.split(',')
         all_services = get_actual_services()
         for service in sys_config['fill_services_first']:
             if service not in all_services:
-                print 'Invalid service name {}. Change your field fill_services_first'.format(service)
+                logging.error('Invalid service name {}. Change your field fill_services_first'.format(service))
                 exit()
 
     # Configuration parameters relating to the filter step
@@ -1218,7 +1219,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
             max_capacity = get_instance_specs(machine_type)[mr.resource]
             default_raw_alloc = (default_alloc_percentage / 100.0) * max_capacity
             mr_allocation[mr] = default_raw_alloc
-        print mr_allocation
+        logging.info(mr_allocation)
     else:
         # Manual Configuration Possible
         # Parse a CSV
@@ -1236,7 +1237,7 @@ def parse_resource_config_file(resource_config_csv, sys_config):
                 # Convert REPR to RAW AMOUNT
                 if amount_repr == 'PERCENT':
                     if amount <= 0 or amount > 100:
-                        print 'Error: invalid default percentage. Exiting...'
+                        logging.error('Error: invalid default percentage. Exiting...')
                         exit()
                     max_capacity = get_instance_specs(machine_type)[resource]
                     amount = (amount / 100.0) * max_capacity
@@ -1264,7 +1265,7 @@ def validate_configs(sys_config, workload_config):
         if resource in ['CPU-CORE', 'CPU-QUOTA', 'DISK', 'NET', 'MEMORY', '*']:
             continue
         else:
-            print 'Cannot stress a specified resource: {}'.format(resource)
+            logging.warning('Cannot stress a specified resource: {}'.format(resource))
 
 #Possibly will need to be changed as we start using hostnames in Quilt
 def validate_ip(ip_addresses):
@@ -1272,7 +1273,7 @@ def validate_ip(ip_addresses):
         try:
             socket.inet_aton(ip)
         except:
-            print 'The IP Address {} is Invalid'.format(ip)
+            logging.error('The IP Address {} is Invalid'.format(ip))
             exit()
 
 # Installs dependencies on machines if needed
@@ -1291,7 +1292,7 @@ def install_dependencies(workload_config):
     # Hardcoded for apt-app, initializing databases
     if workload_config['type'] == 'apt-app':
         # if len(traffic_machines) != 6:
-        #     print 'Not enough traffic machines supplied. Please check config file. Exiting...'
+        #     logging.info('Not enough traffic machines supplied. Please check config file. Exiting...'
         #     exit()
         # for traffic_machine in traffic_machines:
         #     traffic_client = get_client(traffic_machine)
@@ -1322,7 +1323,7 @@ def filter_mr(mr_allocation, acceptable_resources, acceptable_services, acceptab
         # and it is hard to solve...
 
     for mr in delete_queue:
-        print 'Deleting MR: ', mr.to_string()
+        logging.info('Deleting MR: ', mr.to_string())
         del mr_allocation[mr]
 
     return mr_allocation
@@ -1340,18 +1341,18 @@ def set_mr_provision_detect_id_change(redis_db, mr, new_mr_allocation, workload_
             resource_modifier.set_mr_provision(mr, new_mr_allocation, workload_config)
             no_container_id_error = True
         except SystemError as e:
-            print "Updating the container_id of mr: " + mr.to_string()
+            logging.info("Updating the container_id of mr: " + mr.to_string())
 
-            print "Sleeping for 10 seconds to wait for container reboot..."
+            logging.info("Sleeping for 10 seconds to wait for container reboot...")
             sleep(10)
 
             attempt_count += 1
-            print "Tried {} reconnect attempts".format(attempt_count)
+            logging.info("Tried {} reconnect attempts".format(attempt_count))
             update_mr_id(redis_db, mr)
             pass
 
     if attempt_count == max_attempts:
-        print "ERROR: Tried the maximum number of attempts to reconnect to container. Exiting..."
+        logging.error("Tried the maximum number of attempts to reconnect to container. Exiting...")
         exit()
 
 ### Updates the container_id of mr.
@@ -1367,10 +1368,10 @@ def update_mr_id(redis_db, mr_to_change):
     tbot_datastore.write_service_locations(redis_db, mr_to_change.service_name, new_instance_locations)
 
     if len(new_instance_locations) < len(mr_to_change.instances):
-        print "Container not yet rebooted."
+        logging.warning("Container not yet rebooted.")
     else:
         mr_to_change.instances = new_instance_locations
-        print "Container ID replaced successfully"
+        logging.info("Container ID replaced successfully")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -1382,7 +1383,7 @@ if __name__ == "__main__":
 
     # Setup Logging
     logging.basicConfig(filename=args.log, level=logging.INFO)
-    logging.info('Started')
+    logging.info('Started Logging')
 
     sys_config, workload_config, filter_config = parse_config_file(args.config_file)
     mr_allocation = parse_resource_config_file(args.resource_config, sys_config)
@@ -1409,11 +1410,11 @@ if __name__ == "__main__":
             'spark.cores.max': '48'
         }
         workload_config['instances'] = service_to_deployment['hantaowang/bcd-spark'] + service_to_deployment['hantaowang/bcd-spark-master']
-        print workload_config
+        logging.info(workload_config)
         
     experiment_start = time.time()
     run(sys_config, workload_config, filter_config, mr_allocation, args.last_completed_iter)
     experiment_end = time.time()
 
     # Record the time and the number of MRs visited
-    print 'The experiment runs for a total of {}'.format(experiment_end - experiment_start)
+    logging.info('The experiment runs for a total of {}'.format(experiment_end - experiment_start))

--- a/src/run_throttlebot.py
+++ b/src/run_throttlebot.py
@@ -1323,7 +1323,7 @@ def filter_mr(mr_allocation, acceptable_resources, acceptable_services, acceptab
         # and it is hard to solve...
 
     for mr in delete_queue:
-        logging.info('Deleting MR: ', mr.to_string())
+        logging.info('Deleting MR: {}'.format(mr.to_string()))
         del mr_allocation[mr]
 
     return mr_allocation

--- a/src/set_resources.py
+++ b/src/set_resources.py
@@ -3,6 +3,7 @@ import socket
 from modify_resources import *
 from remote_execution import *
 
+import logging
 
 """
 Step 1:
@@ -31,12 +32,12 @@ def generate_empty_file(name):
 
 def error_message(index, e_type):
     if e_type == 'ip':
-        print "Error on line {}. IP is not valid.".format(index)
+        logging.error("Error on line {}. IP is not valid.".format(index)))
     elif e_type == 'value':
-        print "Error on line {}. Resource values must be integers.".format(index)
+        logging.error("Error on line {}. Resource values must be integers.".format(index))
     elif e_type == 'cpu':
-        print "Error on line {}. CPU values must be between 0 and 100. (100 as MAX CPU)".format(index)
-    print "Exiting script"
+        logging.error("Error on line {}. CPU values must be between 0 and 100. (100 as MAX CPU)".format(index))
+    logging.error("Exiting script")
 
 
 if __name__ == "__main__":
@@ -71,7 +72,7 @@ if __name__ == "__main__":
                 ssh_clients[ip_address] = get_client(ip_address)
             ssh_client = ssh_clients[ip_address]
             #
-            # print 'Now setting {} {}\'s resources'.format(ip_address, container_id)
+            # logging.info('Now setting {} {}\'s resources'.format(ip_address, container_id))
             #
             # Setting CPU Cores
             # try:
@@ -115,12 +116,12 @@ if __name__ == "__main__":
                 try:
                     reset_egress_network_bandwidth(ssh_client, container_id)
                 except:
-                    print 'Warning: Container {}\'s network cannot be reset'.format(container_id)
+                    logging.warning('Container {}\'s network cannot be reset'.format(container_id))
             else:
                 try:
                     set_egress_network_bandwidth(ssh_client, container_id, net_bps)
                 except:
-                    print 'Warning: Container {}\'s network cannot be set'.format(container_id)
+                    logging.warning('Container {}\'s network cannot be set'.format(container_id))
 
             line_numb += 1
 
@@ -132,5 +133,5 @@ if __name__ == "__main__":
                 exit()
             set_memory_size(ssh_client, container_id, memory_b)
 
-        print "Container resources were applied."
+        logging.info("Container resources were applied.")
         exit()

--- a/src/stress_analyzer.py
+++ b/src/stress_analyzer.py
@@ -9,6 +9,8 @@ import redis_resource as resource_datastore
 
 from mr import MR
 
+import logging
+
 ### Pre-defined blacklist (Temporary)
 blacklist = ['quilt/ovs', 'google/cadvisor:v0.24.1', 'quay.io/coreos/etcd:v3.0.2', 'mchang6137/quilt:latest', 'hantaowang/lumbersexual']
 
@@ -18,7 +20,7 @@ def generate_mr_from_policy(redis_db, stress_policy):
     if stress_policy == 'ALL':
         return resource_datastore.get_all_mrs(redis_db)
     else:
-        print 'This stress policy does not exist; defaulting to ALL stress'
+        logging.warning('This stress policy does not exist; defaulting to ALL stress')
         return resource_datastore.get_all_mrs(redis_db)
 
 # Policy that returns all MRs subject to restrictions on
@@ -26,14 +28,14 @@ def generate_mr_from_policy(redis_db, stress_policy):
 def get_all_mrs_cluster(vm_list, services, resources):
     mr_schedule = []
     service_to_deployment = get_service_placements(vm_list)
-    print 'printing service to deployment {}'.format(service_to_deployment)
+    logging.info('printing service to deployment {}'.format(service_to_deployment))
     
     for service in service_to_deployment:
         deployments = service_to_deployment[service]
         for resource in resources:
             mr_schedule.append(MR(service, resource, deployments))
 
-    print 'mr schedule is {}'.format(mr_schedule)
+    logging.info('mr schedule is {}'.format(mr_schedule))
     return mr_schedule
 
 # Temporary main method to test get_container_ids function

--- a/src/weighting_conversions.py
+++ b/src/weighting_conversions.py
@@ -11,6 +11,8 @@ Returns the new bandwdith
 from modify_resources import *
 from remote_execution import *
 
+import logging
+
 # Converts a change in resource provisioning to raw change
 # Example: 20% -> 24 Gbps
 def convert_percent_to_raw(mr, current_mr_allocation, weight_change=0):
@@ -25,7 +27,7 @@ def convert_percent_to_raw(mr, current_mr_allocation, weight_change=0):
     elif mr.resource == 'MEMORY':
         return weighting_to_memory(weight_change, current_mr_allocation, mr.instances)
     else:
-        print 'INVALID resource'
+        logging.error('INVALID resource')
         exit()
 
 # Change the networking capacity
@@ -55,16 +57,16 @@ def weighting_to_cpu_quota(weight_change, current_alloc):
 # This is a special case, unlike the other types of stressing
 def weighting_to_cpu_cores(weight_change, current_alloc):
     assert current_alloc > 0
-    print 'hi', current_alloc
+    logging.info('hi', current_alloc)
     new_cores = round(current_alloc + (weight_change / 100.0) * current_alloc)
-    print 'hi2', new_cores
+    logging.info('hi2', new_cores)
     if new_cores == current_alloc:
         if weight_change < 0:
             new_cores = current_alloc - 1
         else:
             new_cores = current_alloc + 1
             if new_cores <= 0:
-                print 'Cannot shrink the number of cores anymore'
+                logging.warning('Cannot shrink the number of cores anymore')
             return 1
 
     return new_cores

--- a/src/weighting_conversions.py
+++ b/src/weighting_conversions.py
@@ -57,9 +57,9 @@ def weighting_to_cpu_quota(weight_change, current_alloc):
 # This is a special case, unlike the other types of stressing
 def weighting_to_cpu_cores(weight_change, current_alloc):
     assert current_alloc > 0
-    logging.info('hi', current_alloc)
+    logging.info('current_alloc {}'.format(current_alloc))
     new_cores = round(current_alloc + (weight_change / 100.0) * current_alloc)
-    logging.info('hi2', new_cores)
+    logging.info('new_cores {}'.format(new_cores))
     if new_cores == current_alloc:
         if weight_change < 0:
             new_cores = current_alloc - 1


### PR DESCRIPTION
Print statements changed to either logging.info or logging.warning for all python files except present_results.py.

For users to output all logs to a specific file, I added an optional --log flag to run_throttlebot.py and added documentation to the end of README.md. If the user does not specify the log file, the results are simply printed into stdout.

Also fixed very minor bug with experiment_count in backtrack.

[Example output](https://www.ocf.berkeley.edu/~emersonh/throttlebot_logs/testmr3.log)